### PR TITLE
Remove dangling references to the harry-runner module

### DIFF
--- a/harry-integration-external/pom.xml
+++ b/harry-integration-external/pom.xml
@@ -40,12 +40,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.cassandra</groupId>
-            <artifactId>harry-runner</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/harry-integration/pom.xml
+++ b/harry-integration/pom.xml
@@ -41,12 +41,6 @@
 
         <dependency>
             <groupId>org.apache.cassandra</groupId>
-            <artifactId>harry-runner</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-dtest-shaded</artifactId>
         </dependency>
 


### PR DESCRIPTION
The harry-runner module was removed in #5 but it was still referenced as a dependency by other modules.
This went unnoticed because the jar was already cached in the Maven repo, but since it's not being used anywhere in the code, simply removing the dependencies from the POMs is enough.