### PR TITLE
Added a wrap script to config test from cmdline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,12 @@
 
 DOCKER_REPO   = org.apache.cassandra/harry/harry-runner
 
-img:
+mvn:
 	rm -fr shared/*
-	mvn clean && mvn package -DskipTests && docker build -t ${DOCKER_REPO}:latest-local ./ -f docker/Dockerfile.local
+	mvn clean && mvn package -DskipTests
+
+img: mvn
+	docker build -t ${DOCKER_REPO}:latest-local ./ -f docker/Dockerfile.local
 
 run: img
 	docker run -v `pwd`/shared:/shared -it ${DOCKER_REPO}:latest-local

--- a/scripts/cassandra-harry
+++ b/scripts/cassandra-harry
@@ -4,6 +4,54 @@ if [ "x$HARRY_HOME" == 'x' ]; then
     HARRY_HOME=~/cassandra-harry
 fi
 
+print_usage() {
+    cat <<EOF
+Usage: cassandra-harry [options]
+
+Options:
+  -node      ip address  node's ip
+  -run-time  number      run time, unit: hours
+  -run-time-unit unit    unit of run time, HOURS, MINUTES
+  -help                  this helpful message
+EOF
+    exit 1
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        "-node")
+            node="$2"
+            shift 2
+            ;;
+        "-run-time")
+            run_time="$2"
+            shift 2
+            ;;
+        "-run-time-unit")
+            run_time_unit="$2"
+            shift 2
+            ;;
+        "-help")
+            shift 1
+	    print_usage
+            ;;
+        *)
+	    print_usage
+            ;;
+    esac
+done
+
+
+if [[ ! -z $node ]]; then
+    sed -i -e "s/contact_points:.*/contact_points: $node/g" $HARRY_HOME/conf/external.yaml
+fi
+if [[ ! -z $run_time ]]; then
+    sed -i -e "s/run_time:.*/run_time: $run_time/g" $HARRY_HOME/conf/external.yaml
+fi
+if [[ ! -z $run_time_unit ]]; then
+    sed -i -e "s/run_time_unit:.*/run_time_unit: \"$run_time_unit\"/g" $HARRY_HOME/conf/external.yaml
+fi
+
 java -Dlogback.configurationFile=$HARRY_HOME/test/conf/logback-dtest.xml \
      -jar $HARRY_HOME/harry-integration-external/target/harry-integration-external-0.0.1-SNAPSHOT.jar \
      $HARRY_HOME/conf/external.yaml

--- a/scripts/cassandra-harry
+++ b/scripts/cassandra-harry
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "x$HARRY_HOME" == 'x' ]; then
+    HARRY_HOME=~/cassandra-harry
+fi
+
+java -Dlogback.configurationFile=$HARRY_HOME/test/conf/logback-dtest.xml \
+     -jar $HARRY_HOME/harry-integration-external/target/harry-integration-external-0.0.1-SNAPSHOT.jar \
+     $HARRY_HOME/conf/external.yaml

--- a/scylla-usage.md
+++ b/scylla-usage.md
@@ -1,0 +1,15 @@
+
+### Install
+
+```
+git clone -b scylla-branch https://github.com/amoskong/cassandra-harry
+cd cassandra-harry
+make mvn
+sudo ln -s `realpath scripts/cassandra-harry` /usr/bin/cassandra-harry
+```
+
+### Execute
+
+```
+HARRY_HOME=~/cassandra-harry cassandra-harry
+```

--- a/scylla-usage.md
+++ b/scylla-usage.md
@@ -11,5 +11,5 @@ sudo ln -s `realpath scripts/cassandra-harry` /usr/bin/cassandra-harry
 ### Execute
 
 ```
-HARRY_HOME=~/cassandra-harry cassandra-harry
+HARRY_HOME=~/cassandra-harry cassandra-harry -run-time 2 -run-time-unit HOURS
 ```


### PR DESCRIPTION
Hello, this PR contains 3 patches.

script: add options to cassandra-harry script
    
    This patch added options to wrap script, it supported to assign test
    duraton from cmdline.
    
scripts: add scripts/cassandra-harry
    
    We want to use cassandra-harry in automation test, and it's not
    convenient to set eveything in yaml config.
    
    This patch added a script to accept the cmdline options and editing the
    yaml config.

Makefile: support to build without creating docker image
    
    When external cluster is used, docker isn't needed.
