### PR TITLE
disable harry-integration local (in-jvm) module for standalone mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ run: img
 
 run-last:
 	docker run -v `pwd`/shared:/shared -it ${DOCKER_REPO}:latest-local
+
+standalone:
+	rm -fr shared/*
+	mvn clean && mvn package -DskipTests -P standalone

--- a/conf/external.yaml
+++ b/conf/external.yaml
@@ -35,9 +35,6 @@ clock:
     epoch_length: 1
     epoch_time_unit: "SECONDS"
 
-run_time: 2
-run_time_unit: "HOURS"
-
 # System under test: a Cassandra node or cluster. Default implementation is in_jvm (in-jvm DTest cluster).
 # Harry also supports external clusters.
 system_under_test:
@@ -48,10 +45,10 @@ system_under_test:
     password: null
 
 # Model is responsible for tracking logical timestamps that
-model:
-  exhaustive_checker:
-    max_seen_lts: 19
-    max_complete_lts: 16
+# model:
+#  exhaustive_checker:
+#    max_seen_lts: 19
+#    max_complete_lts: 16
 
 # Partition descriptor selector controls how partitions is selected based on the current logical
 # timestamp. Default implementation is a sliding window of partition descriptors that will visit
@@ -92,6 +89,9 @@ clustering_descriptor_selector:
 # and model state.
 runner:
   sequential:
+    run_time: 2
+    run_time_unit: "HOURS"
+
     visitors:
       - logging:
           row_visitor:

--- a/pom.xml
+++ b/pom.xml
@@ -42,13 +42,26 @@
     <version>0.0.1-SNAPSHOT</version>
 
     <name>Harry</name>
-
-    <modules>
-        <module>harry-core</module>
-        <module>harry-integration</module>
-        <module>harry-integration-external</module>
-    </modules>
-
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+               <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>harry-core</module>
+                <module>harry-integration</module>
+                <module>harry-integration-external</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>standalone</id>
+            <modules>
+                <module>harry-core</module>
+                <module>harry-integration-external</module>
+            </modules>
+        </profile>
+    </profiles>
     <properties>
         <javac.target>1.8</javac.target>
         <harry.version>0.0.1-SNAPSHOT</harry.version>


### PR DESCRIPTION
In case we don't need the docker integration of `harry-integration`
and we are using an external running cassandra

Signed-off-by: Amos Kong <amos@scylladb.com>