### PR TITLE
Improvements / changes required for Transactional Metadata testing:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,62 @@
+
 # Harry, a fuzz testing tool for Apache Cassandra
 
-The project aims to generate _reproducible_ workloads that are as close to real-life
-as possible, while being able to _efficiently_ verify the cluster state against
-the model without pausing the workload itself.
+The project aims to generate _reproducible_ workloads that are as close to real-life as possible, while being able to
+_efficiently_ verify the cluster state against the model without pausing the workload itself.
 
-# TL;DR
+## Getting Started in under 5 minutes
 
-One way to see Harry is as a read/write stress tool that can check if the read results
-are consistent with what it knows that it has written. This means that in order to test
-Apache Cassandra with Harry, all you need is to run Harry.
+Harry can operate as a straightforward read/write "correctness stress tool" that will check to ensure reads on a cluster
+are consistent with what it knows it wrote to the cluster. You have a couple options for this.
 
-If you're using an external cluster (i.e. `./bin/cassandra -f`, CCM, docker, kubernetes,
-or just a deployed cluster), just use the command line mini stress tool:
+### Option 1: Test a local cassandra branch using harry-stress.sh
 
+1. Start your local cassandra node
+2. Use harry-stress.sh:
+
+```bash
+./harry-stress.sh --help
+
+usage: harry-stress.sh [args]
+  -f --flag           Flag last run as a failure (dir name + touch file indicating)
+  -t --title          Optional title to decorate the results directory with internally in 'title.txt'
+  -d --duration       Time in ms to run test (default 60000)
+  -m --minutes        Alternate duration in minutes
+  -r --read           Read threads. default 2
+  -w --write          Write threads. default 2
+  -s --seed           seed. Defaults to random in 0-1e13
+  -c --conf           .yaml config file. Defaults to conf/external.yaml
+  -v --validate       validation type. Defaults to validate-all
 ```
-make stress ARGS="conf/external.yaml --read=2 --write=2 --duration=60000 --validate-all-local"
+
+An example run:
+`./harry-stress.sh -s 1234 -r 3 -w 3 -t my_custom_branch_test_1 -m 5`
+
+The above will run a test using seed 1234 with 3 read threads, 3 write threads, for 5 minutes, and record the output (
+seed, command, and stress output) in `results/my_custom_branch_test_1`, validating that everything it wrote it finds in
+the database upon read. If there's a failure, you can rapidly flag the last test run as a failure
+with `./harry-stress.sh -f`
+
+Further config params can be found in `conf/external.yaml` or whatever custom .yaml file you've pointed to via
+the `-c | --conf` flag including things like schema, partition sizes, timestamp generation rules, authentication params,
+ratios for different mutation query types, and more.
+
+### Option 2: Running things manually lower in the stack:
+
+The make file has a stress target where you can more directly access all available ARGS rather than restricting yourself
+to the convenience script above. If you're using an external cluster (i.e. `./bin/cassandra -f`, CCM, docker,
+kubernetes, or just a deployed cluster), the mini stress tool can be used directly as follows:
+
+```bash
+# In one terminal; this is needed for the local cassandra dependencies
+$ make run-cassandra
+
+# In another terminal
+$ make stress ARGS="conf/external.yaml --read=2 --write=2 --duration=60000 --validate-all-local"
 ```
 
-This command will start perform concurrent read/write workload, 2 read and 2 write threads for
-60 seconds, and will validate presence of each written row on each node locally when it
-concludes. If it sees any inconsistencies, it will inform you accordingly. There are plenty
-configurables in the configuration files (schema, partition size, timestamp generation rules,
-authentication params, ratios for different mutation query types, and many more).
+This command will start a client that performs a concurrent read/write workload, 2 read and 2 write threads for 60
+seconds. Much like the hary-stress.sh script, if the runner sees any inconsistencies it will inform you accordingly.
 
 An equivalent for an in-jvm cluster is:
 
@@ -51,81 +86,145 @@ try (Cluster cluster = builder().withNodes(3)
 }
 ```
 
-# What's available
+Running sequential read/write workload (i.e. reads strictly following writes, without overlaps), for more determinism is
+possible with:
+
+```
+$ make stress ARGS="conf/external.yaml --write-before-read --duration=60000 --validate-all"
+```
+
+# I've found a falsification. What now?
+
+There is no one-size-fits-all solution for debugging a falsification. We did try to create a shrinker, but unfortunately
+without Simulator, shrinker only works for issues that are non-concurrent in nature, since there's no way to create a
+stable repro otherwise. That said, there are several things that might get you started and inspire further ideas about
+how to debug the issue.
+
+First of all, understand whether or not the issue is likely to be concurrent in nature. If you re-run your test with the
+same seed, but see no falsification, and it fails only sporadically, and often on different logical timestamp, it is
+likely that the issue is, in fact concurrent. Here, it is important to note that when you are running concurrent
+read/write workload, you will get different interleaving of reads and writes every time you do this. If you have reasons
+to think that you're seeing the falsification because a read has queried a specific partition state, try re-running your
+test with sequential runner (`--write-before-read`) if you are using ministress.
+
+If you can get a stable repro with a sequential runner, you're in luck. Now all you need to do is to add logs everywhere
+and understand what might be causing it. But even if you do not have a stable repro, you are still likely to follow the
+same steps:
+
+* Inspect the error itself. Do Cassandra-returned results make sense? Is anything out of order? Are there any duplicates
+  or gaps?
+* Switch to logging mutating visitor and closely inspect its output. Closely inspect the output of the model. Do the
+  values make sense?
+* Check the output of data tracker. Does the model or Cassandra have missing columns or rows? Do these outputs contain
+  latest logical timestamps for each of the operations from the log? How about in-flight operations?
+* Filter out relevant operation log entries and inspect them closely. Given these operations, does the output of the
+  model, or output of the database make most sense?
+
+Next, you might want to try to narrow down the scope of the problem. Depending on what the falsification looks like, use
+your Cassandra knowledge to see what might apply in your situation:
+
+* Try checking if changing schema to use different column types does anything.
+* Try disabling range deletes, regular deletes, or column deletes.
+* Try changing the size of partition and see if the issue still reproduces.
+* Try disabling static columns.
+
+To avoid listing every feature in Harry, it suffices to say you should try to enable/disable features that make sense
+in the given context, and try to find the combination that avoids the failure, or a minimal combination that still
+reproduces the issue. Your first goal should be to find a _stable repro_, even if it involves modifying Cassandra or
+Harry, or taking the operations, and composing the repro manually. Having a stable repro will make finding a cause much
+simpler. Sometimes you will find the cause before you have a stable repro, in which case, you _still_ have to produce a
+stable repro to make things simpler for the reviewer, and to include it into the test suite of your patch.
+
+Lastly, *be patient*. Debugging falsifications is often a multi-hour endeavour, and things do not always jump out at you,
+so you might have to spend a significant amount of time tracking the problem down. Once you have found it, it is very
+rewarding.
+
+## Further Reading
+* [Harry: An open-source fuzz testing and verification tool for Apache Cassandra](https://cassandra.apache.org/_/blog/Harry-an-Open-Source-Fuzz-Testing-and-Verification-Tool-for-Apache-Cassandra.html)
+
+---
+# Technical and Implementation Details
 
 ## System Under Test implementations
 
- * `in_jvm/InJvmSut` - simple in-JVM-dtest system under test.
- * `println/PrintlnSut` - system under test that prints to sdtout instead of executing queries on the cluster; useful for debugging.
- * `mixed_in_jvm/MixedVersionInJvmSut` - in-JVM-dtest system under test that works with mixed version clusters.
- * `external/ExternalClusterSut` - system under test that works with CCM, Docker, Kubernetes, or cluster you may. 
-   have deployed elsewhere 
+* `in_jvm/InJvmSut` - simple in-JVM-dtest system under test.
+* `println/PrintlnSut` - system under test that prints to sdtout instead of executing queries on the cluster; useful for
+  debugging.
+* `mixed_in_jvm/MixedVersionInJvmSut` - in-JVM-dtest system under test that works with mixed version clusters.
+* `external/ExternalClusterSut` - system under test that works with CCM, Docker, Kubernetes, or cluster you may. have
+  deployed elsewhere
 
 Both in-JVM SUTs have fault-injecting functionality available.
 
 ## Visitors
 
-  * `single/SingleValidator` - visitor that runs several different read queries against a single partition that is associated with current logical timestamp, and validates their results using given model. 
-  * `all_partitions/AllPartitionsValidator` - concurrently validates all partitions that were visited during this run.
-  * `repair_and_validate_local_states/RepairingLocalStateValidator` - similar to `AllPartitionsValidator`, but performs repair before checking node states.
-  * `mutating/MutatingVisitor` - visitor that performs all sorts of mutations.
-  * `logging/LoggingVisitor` - similar to `MutatingVisitor`, but also logs all operations to a file; useful for debug purposes.
-  * `corrupting/CorruptingVisitor` - visitor that will deliberately change data in the partition it visits. Useful for negative tests (i.e. to ensure that your model actually detects data inconsistencies). 
+* `single/SingleValidator` - visitor that runs several different read queries against a single partition that is
+  associated with current logical timestamp, and validates their results using given model.
+* `all_partitions/AllPartitionsValidator` - concurrently validates all partitions that were visited during this run.
+* `repair_and_validate_local_states/RepairingLocalStateValidator` - similar to `AllPartitionsValidator`, but performs
+  repair before checking node states.
+* `mutating/MutatingVisitor` - visitor that performs all sorts of mutations.
+* `logging/LoggingVisitor` - similar to `MutatingVisitor`, but also logs all operations to a file; useful for debug
+  purposes.
+* `corrupting/CorruptingVisitor` - visitor that will deliberately change data in the partition it visits. Useful for
+  negative tests (i.e. to ensure that your model actually detects data inconsistencies).
 
 And more.
 
 ## Models
 
-  * `querying_no_op/QueryingNoOpValidator` - a model that can be used to "simply" run random queries.
-  * `quiescent_checker/QuiescentChecker` - a model that can be used to verify results of any read that has no writes to the same partition_ concurrent to it. Should be used in conjunction with locking data tracker.
-  * `quiescent_local_state_checker/QuiescentLocalStateChecker` - a model that can check local states of each replica that has to own 
+* `querying_no_op/QueryingNoOpValidator` - a model that can be used to "simply" run random queries.
+* `quiescent_checker/QuiescentChecker` - a model that can be used to verify results of any read that has no writes to
+  the same partition_ concurrent to it. Should be used in conjunction with locking data tracker.
+* `quiescent_local_state_checker/QuiescentLocalStateChecker` - a model that can check local states of each replica that
+  has to own
 
-## Runners 
+## Runners
 
-  * `sequential/SequentialRunner` - runs all visitors sequentially, in the loop, for a specified amount of time; useful for simple tests that do not have to exercise concurrent read/write path.   
-  * `concurrent/ConcurrentRunner` - runs all visitors concurrently, each visitor in its own thread, looped, for a specified amount of time; useful for things like concurrent read/write workloads.
-  * `chain/ChainRunner` - receives other runners as input, and runs them one after another once. Useful for both simple and complex scenarios that involve both read/write workloads, validating all partitions, exercising other node-local or cluster-wide operations.
-  * `staged/StagedRunner` - receives other runners (stages) as input, and runs them one after another in a loop; useful for implementing complex scenarios, such as read/write workloads followed by some cluster changing operations. 
+* `sequential/SequentialRunner` - runs all visitors sequentially, in the loop, for a specified amount of time; useful
+  for simple tests that do not have to exercise concurrent read/write path.
+* `concurrent/ConcurrentRunner` - runs all visitors concurrently, each visitor in its own thread, looped, for a
+  specified amount of time; useful for things like concurrent read/write workloads.
+* `chain/ChainRunner` - receives other runners as input, and runs them one after another once. Useful for both simple
+  and complex scenarios that involve both read/write workloads, validating all partitions, exercising other node-local
+  or cluster-wide operations.
+* `staged/StagedRunner` - receives other runners (stages) as input, and runs them one after another in a loop; useful
+  for implementing complex scenarios, such as read/write workloads followed by some cluster changing operations.
 
 ## Clock
-  
-  * `approximate_monotonic/ApproxomateMonotonicClock` - a timestamp supplier implementation that tries to keep as close to real time as possible, while preserving mapping from real-time to logical timestamps.
-  * `offset/OffsetClock` - a (monotonic) clock that supplies timestamps that do not have any relation to real time.
+
+* `approximate_monotonic/ApproxomateMonotonicClock` - a timestamp supplier implementation that tries to keep as close to
+  real time as possible, while preserving mapping from real-time to logical timestamps.
+* `offset/OffsetClock` - a (monotonic) clock that supplies timestamps that do not have any relation to real time.
 
 # Introduction
 
 Harry has two primary modes of functionality:
 
-  * Unit test mode: in which you define specific sequences of
-    operations and let Harry test these operations using different
-    schemas and conditions.
-  * Exploratory/fuzz mode: in which you define distributions of events
-    rather rather than sequences themselves, and let Harry try out
-    different things.
+* Unit test mode: in which you define specific sequences of
+  operations and let Harry test these operations using different
+  schemas and conditions.
+* Exploratory/fuzz mode: in which you define distributions of events
+  rather rather than sequences themselves, and let Harry try out
+  different things.
 
-Usually, in unit-test mode, we’re applying several write operations to
-the cluster state and then run different read queries and validate
-their results. To learn more about writing unit tests, refer to the "Writing
-Unit Tests" section.
+Usually, in unit-test mode, we’re applying several write operations to the cluster state and then run different read
+queries and validate their results. To learn more about writing unit tests, refer to the "Writing Unit Tests" section.
 
-In exploratory mode, we continuously apply write operations to the
-cluster and validate their state, allowing data size to grow and simulating
-real-life behaviour. To learn more about implementing test cases using
-fuzz mode, refer to the "Implementing Tests" section of this guide, but it's likely
-you'll have to read the rest of this document to implement more
-complex scenarios.
+In exploratory mode, we continuously apply write operations to the cluster and validate their state, allowing data size
+to grow and simulating real-life behaviour. To learn more about implementing test cases using fuzz mode, refer to the "
+Implementing Tests" section of this guide, but it's likely you'll have to read the rest of this document to implement
+more complex scenarios.
 
 # Writing Unit Tests
 
-To write unit tests with Harry, there's no special knowledge required.
-Usually, unit tests are written by simply hardcoding the schema and then writing
-several modification statements one after the other, and then manually validating results
-of a `SELECT` query. This might work for simple scenarios, but there’s still a chance
-that for some other schema or some combination of values the tested feature may not work.
+To write unit tests with Harry, there's no special knowledge required. Usually, unit tests are written by simply
+hardcoding the schema and then writing several modification statements one after the other, and then manually validating
+results of a `SELECT` query. This might work for simple scenarios, but there’s still a chance that for some other schema
+or some combination of values the tested feature may not work.
 
-To improve the situation, we can express the test in more abstract
-terms and, instead of writing it using specific statements, we can
-describe which statement _types_ are to be used:
+To improve the situation, we can express the test in more abstract terms and, instead of writing it using specific
+statements, we can describe which statement _types_ are to be used:
 
 ```
 test(new SchemaGenerators.Builder("harry")
@@ -143,378 +242,288 @@ test(new SchemaGenerators.Builder("harry")
      });
 ```
 
-This spec can be used to generate clusters of different sizes,
-configured with different schemas, executing the given a sequence of
-actions both in isolation, and combined with other randomly generated
-ones, with failure-injection.
+This spec can be used to generate clusters of different sizes, configured with different schemas, executing the given a
+sequence of actions both in isolation, and combined with other randomly generated ones, with failure-injection.
 
-Best of all is that this test will _not only_ ensure that such a
-sequence of actions does not produce an exception, but also would
-ensure that cluster will respond with correct results to _any_ allowed
-read query.
+Best of all is that this test will _not only_ ensure that such a sequence of actions does not produce an exception, but
+also would ensure that cluster will respond with correct results to _any_ allowed read query.
 
-`HistoryBuilder` is using the configuration provided by Harry `Run`, which
-can be written either using `Configuration#ConfigurationBuilder` like
-we did
-[here](https://github.com/apache/cassandra-harry/blob/ddd643ecc904258abe5e2f73d9b612793b0ac0e6/harry-integration/test/harry/model/IntegrationTestBase.java#L91),
-or provided in a [yaml file](https://github.com/apache/cassandra-harry/blob/ddd643ecc904258abe5e2f73d9b612793b0ac0e6/conf/example.yaml).
+`HistoryBuilder` is using the configuration provided by Harry `Run`, which can be written either
+using `Configuration#ConfigurationBuilder` like we
+did [here](https://github.com/apache/cassandra-harry/blob/ddd643ecc904258abe5e2f73d9b612793b0ac0e6/harry-integration/test/harry/model/IntegrationTestBase.java#L91),
+or provided in
+a [yaml file](https://github.com/apache/cassandra-harry/blob/ddd643ecc904258abe5e2f73d9b612793b0ac0e6/conf/example.yaml).
 
-To begin specifying operations for a new partition,
-`HistoryBuilder#nextPartition` has to be called, which returns a
-`PartitionBuilder`. For the commands within this partition, you have
-a choice between:
-  * `PartitionBuilder#simultaneously`, which will execute listed
-  operations with the same timestamp
-  * `PartitionBuilder#sequentially`, which will execute listed operations
-  with monotonically increasing timestamps, giving each operation its
-  own timestamp
+To begin specifying operations for a new partition, `HistoryBuilder#nextPartition` has to be called, which returns
+a `PartitionBuilder`. For the commands within this partition, you have a choice between:
+
+* `PartitionBuilder#simultaneously`, which will execute listed operations with the same timestamp
+* `PartitionBuilder#sequentially`, which will execute listed operations with monotonically increasing timestamps, giving
+  each operation its own timestamp
 
 Similarly, you can choose between:
-  * `PartitionBuilder#randomOrder`, which will execute listed operations
-  in random order
-  * `PartitionBuilder#strictOrder`, which will execute listed operations
-  in the order specified by the user
 
-The rest of operations are self-explanatory: `#insert`, `#update`,
-`#delete`, `#columnDelete`, `#rangeDelete`, `#sliceDelete`,
-`#partitionDelete`, and their plural counterparts.
+* `PartitionBuilder#randomOrder`, which will execute listed operations in random order
+* `PartitionBuilder#strictOrder`, which will execute listed operations in the order specified by the user
 
-After history generated by `HistoryBuilder` is replayed using
-`ReplayingVisitor`, you can use any model (`QuiescentChecker` by
-default) to validate queries.  Queries can be provided manually or
-generated using `QueryGenerator` or `TypedQueryGenerator`.
+The rest of operations are
+self-explanatory: `#insert`, `#update`, `#delete`, `#columnDelete`, `#rangeDelete`, `#sliceDelete`, `#partitionDelete`,
+and their plural counterparts.
+
+After history generated by `HistoryBuilder` is replayed using `ReplayingVisitor`, you can use any
+model (`QuiescentChecker` by default) to validate queries. Queries can be provided manually or generated
+using `QueryGenerator` or `TypedQueryGenerator`.
 
 # Basic Terminology
 
-  * Inflate / inflatable: a process of producing a value (for example, string, or a blob)
-  from a `long` descriptor that uniquely identifies the value.
-  See [data generation](https://github.com/apache/cassandra-harry#data-generation) section
-  of this guide for more details.
-  * Deflate / deflatable: a process of producing the descriptor the value was inflated
-  from during verification. See [model](https://github.com/apache/cassandra-harry#model)
+* Inflate / inflatable: a process of producing a value (for example, string, or a blob) from a `long` descriptor that
+  uniquely identifies the value. See [data generation](https://github.com/apache/cassandra-harry#data-generation)
   section of this guide for more details.
+* Deflate / deflatable: a process of producing the descriptor the value was inflated from during verification.
+  See [model](https://github.com/apache/cassandra-harry#model) section of this guide for more details.
 
-For definitions of logical timestamp, descriptor, and other entities used during
-inflation and deflation, refer to [formal relationships](https://github.com/apache/cassandra-harry#formal-relations-between-entities)
-section.
+For definitions of logical timestamp, descriptor, and other entities used during inflation and deflation, refer
+to [formal relationships](https://github.com/apache/cassandra-harry#formal-relations-between-entities) section.
 
 # Features
 
 Currently, Harry can exercise the following Cassandra functionality:
 
-  * Supported data types: `int8`, `int16`, `int32`, `int64`, `boolean`, `float`,
-  `double`, `ascii`, `uuid`, `timestamp`. Collections are only _inflatable_.
-  * Random schema generation, with an arbitrary number of partition and clustering
-  keys.
-  * Schemas with arbitrary `CLUSTERING ORDER BY`
-  * Randomly generated `INSERT` and `UPDATE` queries with all columns or arbitrary
-  column subset
-  * Randomly generated `DELETE` queries: for a single column, single row, or
-  a range of rows
-  * Inflating and validating entire partitions (with allowed in-flight queries)
-  * Inflating and validating random `SELECT` queries: single row, slices (with single
-  open end), and ranges (with both ends of clusterings specified)
+* Supported data types: `int8`, `int16`, `int32`, `int64`, `boolean`, `float`, `double`, `ascii`, `uuid`, `timestamp`.
+  Collections are only _inflatable_.
+* Random schema generation, with an arbitrary number of partition and clustering keys.
+* Schemas with arbitrary `CLUSTERING ORDER BY`
+* Randomly generated `INSERT` and `UPDATE` queries with all columns or arbitrary column subset
+* Randomly generated `DELETE` queries: for a single column, single row, or a range of rows
+* Inflating and validating entire partitions (with allowed in-flight queries)
+* Inflating and validating random `SELECT` queries: single row, slices (with single open end), and ranges (with both
+  ends of clusterings specified)
 
-Inflating partitions is done using [Reconciler](https://github.com/apache/cassandra-harry/blob/master/harry-core/src/harry/reconciler/Reconciler.java).
-Validating partitions and random queries can be done using [Quiescent Checker](https://github.com/apache/cassandra-harry/blob/master/harry-core/src/harry/model/QuiescentChecker.java)
+Inflating partitions is done
+using [Reconciler](https://github.com/apache/cassandra-harry/blob/master/harry-core/src/harry/reconciler/Reconciler.java).
+Validating partitions and random queries can be done
+using [Quiescent Checker](https://github.com/apache/cassandra-harry/blob/master/harry-core/src/harry/model/QuiescentChecker.java)
 and [Exhaustive Checker](https://github.com/apache/cassandra-harry/blob/master/harry-core/src/harry/model/ExhaustiveChecker.java).
 
-## What's missing
+## Outstanding Work
 
-Harry is by no means feature-complete. Main things that are missing are:
+#### The following have not yet been implemented:
 
-  * Some types (such as collections) are not deflatable
-  * Some types are implemented but are not hooked up (`blob` and `text`) to DSL/generator
-  * Partition deletions are not implemented
-  * 2i queries are not implemented
-  * Compact storage is not implemented
-  * Static columns are not implemented
-  * Fault injection is not implemented
-  * Runner and scheduler are rather rudimentary and require significant rework and proper scheduling
-  * TTL is not supported
-  * Some SELECT queries are not supported: `LIMIT`, `IN`, `GROUP BY`, token range queries
-  * Partition deletions are not implemented
-  * Pagination is not implemented
+* Some types (such as collections) are not deflatable
+* 2i queries are not implemented
+* Fault injection is not implemented (available via Cassandra Simulator)
+* TTL is not supported
+* Some SELECT queries are not supported: `LIMIT`, `IN`, `GROUP BY`, token range queries
 
-Some things, even though are implemented, can be improved or optimized:
+#### Some features can be improved upon or further optimized:
 
-  * RNG should be able to yield less than 64 bits of entropy per step
-  * State tracking should be done in a compact off-heap data stucture
-  * Inflated partition state and per-row operation log should be done in a compact
+* Pagination is currently implemented but hard-coded to a page size of 1
+* RNG should be able to yield less than 64 bits of entropy per step
+* State tracking should be done in a compact off-heap data stucture
+* Inflated partition state and per-row operation log should be done in a compact
   off-heap data structure
-  * Exhaustive checker can be significantly optimized
-  * Harry shouldn't rely on java-driver for query generation
-  * Exhaustive checker should use more precise information from data tracker, not
-  just watermarks
-  * Decision-making about _when_ we visit partitions and/or rows should be improved
+* Decision-making about _when_ we visit partitions and/or rows should be improved
 
-This list of improvements is incomplete, and should only give the reader a rough
-idea about the state of the project. Main goal for the initial release was to make it
-useful, now we can make it fast and feature-complete!
+While thislist of improvements is incomplete, t should give the reader a rough idea about the state of the project.
+The original goal of the project was to drive to stability after the significant storage engine rewrite in
+CASSANDRA-8099 and help remove data loss bugs from the codebase before they got out into the wild. Next steps are to
+integrate it into both CI and into regular daily dev workflows.
 
-# Goals
+# Goals: Reproducibility and Efficiency
 
-_Reproducibility_ is achieved by using the PCG family of random number
-generators and generating schema, configuration, and every step of the workload
-from the repeatable sequence of random numbers. Schema and configuration are
-generated from the _seed_. Each operation is assigned its own monotonically
-increasing _logical timestamp_, which preserves logical operation order between
-different runs.
+_Reproducibility_ is achieved by using the PCG family of random number generators and generating schema, configuration,
+and every step of the workload from the repeatable sequence of random numbers. Schema and configuration are generated
+from the _seed_. Each operation is assigned its own monotonically increasing _logical timestamp_, which preserves
+logical operation order between different runs.
 
-_Efficiency_ is achieved by employing the features of the PCG random number
-generator (walking the sequence of random numbers back and forth), and writing
-value generators in a way that preserves properties of the descriptor it was
+_Efficiency_ is achieved by employing the features of the PCG random number generator (walking the sequence of random
+numbers back and forth), and writing value generators in a way that preserves properties of the descriptor it was
 generated from.
 
 Given a `long` _descriptor_ can be _inflated_ into some value:
-  * value can be _deflated_ back to the descriptor it was generated from
-  (in other words, generation is *invertible*)
-  * two inflated values will sort the same way as two descriptors they
-  were generated from (in other words, generation is *order-preserving*)
 
-These properties are also preserved for the composite values, such
-as clustering and partition keys.
+* value can be _deflated_ back to the descriptor it was generated from (in other words, generation is *invertible*)
+* two inflated values will sort the same way as two descriptors they were generated from (in other words, generation is
+  *order-preserving*)
+
+These properties are also preserved for the composite values, such as clustering and partition keys.
 
 # Components
 
-Every Harry run starts from Configuration. You can find an example configuration
-under `conf/example.yml`.
+Every Harry run starts from Configuration. You can find an example configuration under `conf/example.yml`.
 
-*Clock* is a component responsible for mapping _logical_ timestamps to
-_real-time_ ones. When reproducing test failures, and for validation purposes, a
-snapshot of such be taken to map a real-time timestamp from the value retrieved
-from the database to map it back to the logical timestamp of the operation that
-wrote this value. Given a real-time timestamp, the clock can return a logical
-timestamp, and vice versa.
+*Clock* is a component responsible for mapping _logical_ timestamps to _real-time_ ones. When reproducing test failures,
+and for validation purposes, a snapshot of such be taken to map a real-time timestamp from the value retrieved from the
+database to map it back to the logical timestamp of the operation that wrote this value. Given a real-time timestamp,
+the clock can return a logical timestamp, and vice versa.
 
-*Runner* is a component that schedules operations that change the cluster
-(system under test) and model state.
+*Runner* is a component that schedules operations that change the cluster (system under test) and model state.
 
-*System under test*: a Cassandra node or cluster. Default implementation is
-in_jvm (in-JVM DTest cluster). Harry also supports external clusters.
+*System under test*: a Cassandra node or cluster. Default implementation is in_jvm (in-JVM DTest cluster). Harry also
+supports external clusters.
 
-*Model* is responsible for tracking logical timestamps that system under
-test was notified about.
+*Model* is responsible for tracking logical timestamps that system under test was notified about.
 
-*Partition descriptor selector* controls how partitions are selected based on
-the current logical timestamp. The default implementation is a sliding window of
-partition descriptors that will visit one partition after the other in the
-window `slide_after_repeats` times. After that, it will retire one partition
-descriptor, and pick a new one.
+*Partition descriptor selector* controls how partitions are selected based on the current logical timestamp. The default
+implementation is a sliding window of partition descriptors that will visit one partition after the other in the
+window `slide_after_repeats` times. After that, it will retire one partition descriptor, and pick a new one.
 
-*Clustering descriptor selector* controls how clustering keys are picked within
-the partition: how many rows there can be in a partition, how many rows are
-visited for a logical timestamp, how many operations there will be in batch,
-what kind of operations there will and how often each kind of operation is going
-to occur.
+*Clustering descriptor selector* controls how clustering keys are picked within the partition: how many rows there can
+be in a partition, how many rows are visited for a logical timestamp, how many operations there will be in batch, what
+kind of operations there will and how often each kind of operation is going to occur.
 
 # Implementing Tests
 
-All Harry components are pluggable and can be redefined. However, many
-of the default implementations will cover most of the use-cases, so in
-this guide we’ll focus on ones that are most often used to implement
-different use cases:
+All Harry components are pluggable and can be redefined. However, many of the default implementations will cover most of
+the use-cases, so in this guide we’ll focus on ones that are most often used to implement different use cases:
 
-  * System Under Test: defines how Harry can communicate with
-    Cassandra instances and issue common queries. Examples of a system
-    under test can be a CCM cluster, a “real” Cassandra cluster, or an
-    in-JVM dtest cluster.
-  * Visitor: defines behaviour that gets triggered at a specific
-    logical timestamp. One of the default implementations is
-    MutatingVisitor, which executes write workload against
-    SystemUnderTest. Examples of a visitor, besides a mutating visitor,
-    could be a validator that uses the model to validate results of
-    different queries, a repair runner, or a fault injector.
-  * Model: validates results of read queries by comparing its own
-    internal representation against the results returned by system
-    under test. You can find three simplified implementations of
-    model in this document: Visible Rows Checker, Quiescent Checker,
-    and an Exhaustive Checker.
-  * Runner: defines how operations defined by visitors are
-    executed. Harry includes two default implementations: a sequential
-    and a concurrent runner. Sequential runner allows no overlap
-    between different visitors or logical timestamps. Concurrent
-    runner allows visitors for different timestamps to overlap.
+* System Under Test: defines how Harry can communicate with Cassandra instances and issue common queries. Examples of a
+  system under test can be a CCM cluster, a “real” Cassandra cluster, or an in-JVM dtest cluster.
+* Visitor: defines behaviour that gets triggered at a specific logical timestamp. One of the default implementations is
+  MutatingVisitor, which executes write workload against SystemUnderTest. Examples of a visitor, besides a mutating
+  visitor, could be a validator that uses the model to validate results of different queries, a repair runner, or a
+  fault injector.
+* Model: validates results of read queries by comparing its own internal representation against the results returned by
+  system under test. You can find three simplified implementations of model in this document: Visible Rows Checker,
+  Quiescent Checker, and an Exhaustive Checker.
+* Runner: defines how operations defined by visitors are executed. Harry includes two default implementations: a
+  sequential and a concurrent runner. Sequential runner allows no overlap between different visitors or logical
+  timestamps. Concurrent runner allows visitors for different timestamps to overlap.
 
-System under test is the simplest one to implement: you only need a
-way to execute Cassandra queries. At the moment of writing, all custom
-things, such as nodetool commands, failure injection, etc, are
-implemented using a SUT / visitor combo: visitor knows about internals
-of the cluster it is dealing with.
+System under test is the simplest one to implement: you only need a way to execute Cassandra queries. At the moment of
+writing, all custom things, such as nodetool commands, failure injection, etc, are implemented using a SUT / visitor
+combo: visitor knows about internals of the cluster it is dealing with.
 
-Generally, visitor has to follow the rules specified by
-DescriptorSelector and PdSelector: (it can only visit issue mutations
-against the partition that PdSelector has picked for this LTS), and
-DescriptorSelector (it can visit exactly
-DescriptorSelector#numberOfModifications rows within this partition,
-operations have to have a type specified by #operationKind, clustering
-and value descriptors have to be in accordance with
-DescriptorSelector#cd and DescriptorSelector#vds). The reason for
-these limitations is because model has to be able to reproduce the
-exact sequence of events that was applied to system under test.
+Generally, visitor has to follow the rules specified by DescriptorSelector and PdSelector: (it can only visit issue
+mutations against the partition that PdSelector has picked for this LTS), and DescriptorSelector (it can visit exactly
+DescriptorSelector#numberOfModifications rows within this partition, operations have to have a type specified by
+#operationKind, clustering and value descriptors have to be in accordance with DescriptorSelector#cd and
+DescriptorSelector#vds). The reason for these limitations is because model has to be able to reproduce the exact
+sequence of events that was applied to system under test.
 
-Default implementations of partition and clustering descriptors, used
-in fuzz mode allow to optimise verification. For example, it is
-possible to go find logical timestamps that are visiting the same
-partition as any given logical timestamp. When running Harry in
-unit-test mode, we use a special generating visitor that keeps an
-entire given sequence of events in memory rather than producing it on
-the fly. For reasons of efficiency, we do not use generating visitors
+Default implementations of partition and clustering descriptors, used in fuzz mode allow to optimise verification. For
+example, it is possible to go find logical timestamps that are visiting the same partition as any given logical
+timestamp. When running Harry in unit-test mode, we use a special generating visitor that keeps an entire given sequence
+of events in memory rather than producing it on the fly. For reasons of efficiency, we do not use generating visitors
 for generating and verifying large datasets.
 
 # Formal Relations Between Entities
 
-To be able to implement efficient models, we had to reduce the amount of state
-required for validation to a minimum and try to operate on primitive data values
-most of the time. Any Harry run starts with a `seed`. Given the same
-configuration, and the same seed, we're able to make runs deterministic (in
-other words, records in two clusters created from the same seed are going to
-have different real-time timestamps, but will be otherwise identical; logical
-time stamps will also be identical).
+To be able to implement efficient models, we had to reduce the amount of state required for validation to a minimum and
+try to operate on primitive data values most of the time. Any Harry run starts with a `seed`. Given the same
+configuration, and the same seed, we're able to make runs deterministic (in other words, records in two clusters created
+from the same seed are going to have different real-time timestamps, but will be otherwise identical; logical time
+stamps will also be identical).
 
-Since it's clear how to generate things like random schemas, cluster
-configurations, etc., let's discuss how we're generating data, and why this type
-of generation makes validation efficient.
+Since it's clear how to generate things like random schemas, cluster configurations, etc., let's discuss how we're
+generating data, and why this type of generation makes validation efficient.
 
-First, we're using PCG family of random number generators, which, besides having
-nice characteristics that any RNG should have, have two important features:
+First, we're using PCG family of random number generators, which, besides having nice characteristics that any RNG
+should have, have two important features:
 
-  * Streams: for single seed, we can have several independent _different_
-    streams of random numbers.
-  * Walkability: PCG generators generate a stream of numbers you can walk _back_
-    and _forth_. That is, for any number _n_ that represents a _position_ of the
-    random number in the stream of random numbers, we can get the random number
-    at this position. Conversely, given a random number, we can determine what
-    is its position in the stream. Moreover, knowing a random number, we can
-    determine which number precedes it in the stream of random numbers, and,
-    finally, we can determine how many numbers there are in a stream between the
-    two random numbers.
+* Streams: for single seed, we can have several independent _different_ streams of random numbers.
+* Walkability: PCG generators generate a stream of numbers you can walk _back_ and _forth_. That is, for any number _n_
+  that represents a _position_ of the random number in the stream of random numbers, we can get the random number at
+  this position. Conversely, given a random number, we can determine what is its position in the stream. Moreover,
+  knowing a random number, we can determine which number precedes it in the stream of random numbers, and, finally, we
+  can determine how many numbers there are in a stream between the two random numbers.
 
-Out of these operations, determining the _next_ random number in the sequence
-can be done in constant time, `O(1)`. Advancing generator by _n_ steps can be
-done in `O(log(n))` steps. Since generation is cyclical, advancing the iterator
-backward is equivalent to advancing it by `cardinality - 1` steps. If we're
-generating 64 bits of entropy, advancing by `-1` can be done in 64 steps.
+Out of these operations, determining the _next_ random number in the sequence can be done in constant time, `O(1)`.
+Advancing generator by _n_ steps can be done in `O(log(n))` steps. Since generation is cyclical, advancing the iterator
+backward is equivalent to advancing it by `cardinality - 1` steps. If we're generating 64 bits of entropy, advancing
+by `-1` can be done in 64 steps.
 
 Let's introduce some definitions:
-  * `lts` is a *logical timestamp*, an entity (number in our case), given by the
-    clock, on which some action occurs
-  * `m` is a *modification id*, a sequential number of the modification that
-  occurs on `lts`
-  * `rts` is an approximate real-time as of clock for this run
-  * `pid` is a partition position, a number between `0` and N, for `N` unique
-    generated partitions
-  * `pd` is a partition descriptor, a unique descriptor identifying the
-    partition
-  * `cd` is a clustering descriptor, a unique descriptor identifying row within
-    some partition
+
+* `lts` is a *logical timestamp*, an entity (number in our case), given by the clock, on which some action occurs
+* `m` is a *modification id*, a sequential number of the modification that occurs on `lts`
+* `rts` is an approximate real-time as of clock for this run
+* `pid` is a partition position, a number between `0` and N, for `N` unique generated partitions
+* `pd` is a partition descriptor, a unique descriptor identifying the partition
+* `cd` is a clustering descriptor, a unique descriptor identifying row within some partition
 
 A small introduction that can help to understand the relation between these
 entities. Hierarchically, the generation process looks as follows:
 
-  * `lts` is an entry point, from which the decision process starts
-  * `pd` is picked from `lts`, and determines which partition is going to be
-    visited
-  * for `(pd, lts)` combination, `#mods` (the number of modification batches)
-    and `#rows` (the number of rows per modification batch) is determined. `m`
-    is an index of the modification batch, and `i` is an index of the operation
-    in the modification batch.
-  * `cd` is picked based on `(pd, lts)`, and `n`, a sequential number of the
-    operation among all modification batches
-  * operation type (whether we're going to perform a write, delete, range delete, etc),
-    columns involved in this operation, and values for the modification are picked
-    depending on the `pd`, `lts`, `m`, and `i`
+* `lts` is an entry point, from which the decision process starts
+* `pd` is picked from `lts`, and determines which partition is going to be visited
+* for `(pd, lts)` combination, `#mods` (the number of modification batches) and `#rows` (the number of rows per
+  modification batch) is determined. `m` is an index of the modification batch, and `i` is an index of the operation in
+  the modification batch.
+* `cd` is picked based on `(pd, lts)`, and `n`, a sequential number of the operation among all modification batches
+* operation type (whether we're going to perform a write, delete, range delete, etc), columns involved in this
+  operation, and values for the modification are picked depending on the `pd`, `lts`, `m`, and `i`
 
-Most of this formalization is implemented in `OpSelectors`, and is relied upon
-in`PartitionVisitor` and any implementation of a `Model`.
+Most of this formalization is implemented in `OpSelectors`, and is relied upon in`PartitionVisitor` and any
+implementation of a `Model`.
 
 Random number generation (see `OpSelectors#Rng`):
 
-  * `rng(i, stream[, e])`: returns i'th number drawn from random sequence
-    `stream` producing values with `e` bits of entropy (64 bits for now).
-  * `rng'(s, stream[, e])`: returns `i` of the random number `s` drawn from the
-    random sequence `stream`. This function is an inverse of `rng`.
-  * `next(rnd, stream[, e])` and `prev(rnd, stream[, e])`: the next/previous
-    number relative to `rnd` drawn from random sequence `stream`.
+* `rng(i, stream[, e])`: returns i'th number drawn from random sequence `stream` producing values with `e` bits of
+  entropy (64 bits for now).
+* `rng'(s, stream[, e])`: returns `i` of the random number `s` drawn from the random sequence `stream`. This function is
+  an inverse of `rng`.
+* `next(rnd, stream[, e])` and `prev(rnd, stream[, e])`: the next/previous number relative to `rnd` drawn from random
+  sequence `stream`.
 
-A simple example of a partition descriptor selector is one that is based on a
-sliding window of a size `s`, that slides every `n` iterations. First, we
-determine _where_ the window should start for a given `lts` (in other words, how
-many times it has already slid). After that, we determine which `pd` we pick out
-of `s` available ones. After picking each one of the `s` descriptors `n` times,
-we retire the oldest descriptor and pick a new one to the window. Window start
-and offset are then used as input for the `rng(start + offset, stream)` to make
-sure descriptors are uniformly distributed.
+A simple example of a partition descriptor selector is one that is based on a sliding window of a size `s`, that slides
+every `n` iterations. First, we determine _where_ the window should start for a given `lts` (in other words, how many
+times it has already slid). After that, we determine which `pd` we pick out of `s` available ones. After picking each
+one of the `s` descriptors `n` times, we retire the oldest descriptor and pick a new one to the window. Window start and
+offset are then used as input for the `rng(start + offset, stream)` to make sure descriptors are uniformly distributed.
 
-We can build a clustering descriptor selector in a similar manner. Each
-partition will use its `pd` as a stream id, and pick `cd` from a universe of
-possible `cds` of size `#cds`. On each `lts`, we pick a random `offset`, and
-start picking `#ops` clusterings from this `offset < #cds`, and wrap around to
-index 0 after that. This way, each operation maps to a unique `cd`, and
-`#op` can be determined from `cd` deterministically.
+We can build a clustering descriptor selector in a similar manner. Each partition will use its `pd` as a stream id, and
+pick `cd` from a universe of possible `cds` of size `#cds`. On each `lts`, we pick a random `offset`, and start
+picking `#ops` clusterings from this `offset < #cds`, and wrap around to index 0 after that. This way, each operation
+maps to a unique `cd`, and `#op` can be determined from `cd` deterministically.
 
 # Data Generation
 
-So far, we have established how to generate partition, clustering, and value
-_descriptors_. Now, we need to understand how we can generate data modification
-statements out of these descriptors in a way that helps us to validate data
-later.
+So far, we have established how to generate partition, clustering, and value _descriptors_. Now, we need to understand
+how we can generate data modification statements out of these descriptors in a way that helps us to validate data later.
 
-Since every run has a predefined schema, and by the time we visit a partition we
-have a logical timestamp, we can make the rest of the decisions: pick a number
-of batches we're about to perform, determine what kind of operations each one of
-the batches is going to contain, which rows we're going to visit (clustering for
-each modification operation).
+Since every run has a predefined schema, and by the time we visit a partition we have a logical timestamp, we can make
+the rest of the decisions: pick a number of batches we're about to perform, determine what kind of operations each one
+of the batches is going to contain, which rows we're going to visit (clustering for each modification operation).
 
-To generate a write, we need to know _which partition_ we're going to visit (in
-other words, partition descriptor), _which row_ we'd like to modify (in other
-words, clustering descriptor), _which columns_ we're modifying (in other words,
-a column mask), and, for each modified column - its value. By the time we're
-ready to make an actual query to the database, we already know `pd`, `cd`,
-`rts`, and `vds[]`, which is all we need to "inflate" a write.
+To generate a write, we need to know _which partition_ we're going to visit (in other words, partition descriptor),
+_which row_ we'd like to modify (in other words, clustering descriptor), _which columns_ we're modifying (in other
+words, a column mask), and, for each modified column - its value. By the time we're ready to make an actual query to the
+database, we already know `pd`, `cd`, `rts`, and `vds[]`, which is all we need to "inflate" a write.
 
-To inflate each value descriptor, we take a generator for its datatype, and turn
-its descriptor into the object. This generation process has the following
-important properties:
+To inflate each value descriptor, we take a generator for its datatype, and turn its descriptor into the object. This
+generation process has the following important properties:
 
-  * it is invertible: for every `inflate(vd) -> value`, there's `deflate(value) -> vd`
-  * it is order-preserving: `compare(vd1, vd2) == compare(inflate(vd1), inflate(vd2))`
+* it is invertible: for every `inflate(vd) -> value`, there's `deflate(value) -> vd`
+* it is order-preserving: `compare(vd1, vd2) == compare(inflate(vd1), inflate(vd2))`
 
-Inflating `pd` and `cd` is slightly more involved than inflating `vds`, since
-partition and clustering keys are often composite. This means that `inflate(pd)`
-returns an array of objects, rather just a single object: `inflate(pd) ->
-value[]`, and `deflate(value[]) -> pd`. Just like inflating value descriptors,
-inflating keys preserves order.
+Inflating `pd` and `cd` is slightly more involved than inflating `vds`, since partition and clustering keys are often
+composite. This means that `inflate(pd)` returns an array of objects, rather just a single
+object: `inflate(pd) -> value[]`, and `deflate(value[]) -> pd`. Just like inflating value descriptors, inflating keys
+preserves order.
 
-It is easy to see that, given two modifications: `Update(pd1, cd1, [vd1_1,
-vd2_1, vd3_1], lts1)` and `Update(pd1, cd1, [vd1_2, vd3_2], lts2)`, we will end
-up with a resultset that contains effects of both operations: `ResultSetRow(pd1,
-cd1, [vd1_2@rts2, vd2_1@rts1, vd3_2@rts2])`.
+It is easy to see that, given two modifications: `Update(pd1, cd1, [vd1_1, vd2_1, vd3_1], lts1)`
+and `Update(pd1, cd1, [vd1_2, vd3_2], lts2)`, we will end up with a resultset that contains effects of both
+operations: `ResultSetRow(pd1, cd1, [vd1_2@rts2, vd2_1@rts1, vd3_2@rts2])`.
 
 # Model
 
-Model in Harry ties the rest of the components together and allows us to check
-whether or not data returned by the cluster actually makes sense. The model
-relies on the clock, since we have to convert real-time timestamps of the
-returned values back to logical timestamps, and on descriptor selectors to pick the
-right partition and rows.
+`Model` in Harry ties the rest of the components together and allows us to check whether or not data returned by the
+cluster actually makes sense. The model relies on the clock, since we have to convert real-time timestamps of the
+returned values back to logical timestamps, and on descriptor selectors to pick the right partition and rows.
 
 ## Visible Rows Checker
 
-Let's try to put it all together and build a simple model. The simplest one is a
-visible row checker. It can check if any row in the response returned from the
-database could have been produced by one of the operations. However, it won't be
-able to find errors related to missing rows, and will only notice some cases of
-erroneously overwritten rows.
+Let's try to put it all together and build a simple model. The simplest one is a visible row checker. It can check if
+any row in the response returned from the database could have been produced by one of the operations. However, it won't
+be able to find errors related to missing rows, and will only notice some cases of erroneously overwritten rows.
 
-In the model, we can see a response from the database in its deflated state. In
-other words, instead of the actual values returned, we see their descriptors.
-Every resultset row consists of `pd`, `cd`, `vds[]` (value descriptors), and
-`lts[]` (logical timestamps at which these values were written).
+In the model, we can see a response from the database in its deflated state. In other words, instead of the actual
+values returned, we see their descriptors. Every resultset row consists of `pd`, `cd`, `vds[]` (value descriptors),
+and `lts[]` (logical timestamps at which these values were written).
 
-To validate, we need to iterate through all operations for this partition,
-starting with the latest one the model is aware of. This model has no internal
-state, and validates entire partitions:
+To validate, we need to iterate through all operations for this partition, starting with the latest one the model is
+aware of. This model has no internal state, and validates entire partitions:
 
 ```
 void validatePartitionState(long validationLts, List<ResultSetRow> rows) {
@@ -566,29 +575,24 @@ void validatePartitionState(long validationLts, List<ResultSetRow> rows) {
 }
 ```
 
-As you can see, all validation is done using deflated `ResultSetRows`, which
-contain enough data to say which logical timestamp each value was written with,
-and which value descriptor each value has. This model can also validate data
+As you can see, all validation is done using deflated `ResultSetRows`, which contain enough data to say which logical
+timestamp each value was written with, and which value descriptor each value has. This model can also validate data
 concurrently to the ongoing data modification operations.
 
 ## Quiescent Checker
 
-Let's consider one more checker. It'll be more powerful than the visible rows
-checker in one way since it can find any inconsistency in data (incorrect
-timestamp, missing or additional row, rows coming in the wrong order, etc), but
-it'll also have one limitation: it won't be able to run concurrently with data
-modification statements. This means that for this model to be used, we should
-have no _in-flight_ queries, and all queries have to be in a deterministic state
-by the time we're validating their results.
+Let's consider one more checker. It'll be more powerful than the visible rows checker in one way since it can find any
+inconsistency in data (incorrect timestamp, missing or additional row, rows coming in the wrong order, etc), but it'll
+also have one limitation: it won't be able to run concurrently with data modification statements. This means that for
+this model to be used, we should have no _in-flight_ queries, and all queries have to be in a deterministic state by the
+time we're validating their results.
 
-For this checker, we assume that we have a component that is called
-`Reconciler`, which can inflate partition state _up to some_ `lts`. `Reconciler`
-works by simply applying each modification in the same order they were applied
-to the cluster, and using standard Cassandra data reconciliation rules (last
-write wins / DELETE wins over INSERT in case of a timestamp collision).
+For this checker, we assume that we have a component that is called `Reconciler`, which can inflate partition state _up
+to some_ `lts`. `Reconciler` works by simply applying each modification in the same order they were applied to the
+cluster, and using standard Cassandra data reconciliation rules (last write wins / DELETE wins over INSERT in case of a
+timestamp collision).
 
-With this component, and knowing that there can be no in-fight queries, we can
-validate data in the following way:
+With this component, and knowing that there can be no in-fight queries, we can validate data in the following way:
 
 ```
 public void validatePartitionState(Iterator<ResultSetRow> actual, Query query) {
@@ -639,20 +643,19 @@ interested in `lts`, `opId`, and visibility (whether or not it is still
 in-flight) of each modification operation. To be able to give a reliable result,
 we need to make sure we follow these rules:
 
-  * every operation model _thinks_ should be visible, has to be visible
-  * every operation model _thinks_ should be invisible, has to be invisible
-  * every operation model doesn't know the state of (i.e., it is still
-    in-flight) can be _either_ visible _invisible_
-  * there can be no state in the database that model is not aware of (in other words,
-    we either can _explain_ how a row came to be, or we conclude that the row is
-    erroneous)
+* every operation model _thinks_ should be visible, has to be visible
+* every operation model _thinks_ should be invisible, has to be invisible
+* every operation model doesn't know the state of (i.e., it is still
+  in-flight) can be _either_ visible _invisible_
+* there can be no state in the database that model is not aware of (in other words,
+  we either can _explain_ how a row came to be, or we conclude that the row is
+  erroneous)
 
 A naive way to do this would be to inflate every possible partition state, where
 every in-flight operation would be either visible or invisible, but this gets
 costly very quickly since the number of possible combinations grows
 exponentially. A better (and simpler) way to do this is to iterate all
 operations and keep the state of "explained" operations:
-
 
 ```
 public class RowValidationState {
@@ -693,52 +696,40 @@ public void validatePartitionState(long verificationLts, PeekingIterator<ResultS
 }
 ```
 
-Now, we have to implement `validateRow` and `validateNoRow`. `validateNoRow` is
-easy: we only need to make sure that a set of operations results in an invisible
-row. Since we're iterating operations in reverse order, if we encounter a delete
-not followed by any writes, we can conclude that the row is invisible and exit
-early. If there's a write that is not followed by a delete, and the row isn't
-covered by a range tombstone, we know it's an error.
+Now, we have to implement `validateRow` and `validateNoRow`. `validateNoRow` is easy: we only need to make sure that a
+set of operations results in an invisible row. Since we're iterating operations in reverse order, if we encounter a
+delete not followed by any writes, we can conclude that the row is invisible and exit early. If there's a write that is
+not followed by a delete, and the row isn't covered by a range tombstone, we know it's an error.
 
-`validateRow` only has to iterate operations in reverse order until it can
-explain the value in every column. For example, if a value is `UNOBSERVED`, and
-the first thing we encounter is a `DELETE` that removes this column, we only
-need to make sure that the value is actually `null`, in which case we can
-conclude that the value can be explained as `REMOVED`.
+`validateRow` only has to iterate operations in reverse order until it can explain the value in every column. For
+example, if a value is `UNOBSERVED`, and the first thing we encounter is a `DELETE` that removes this column, we only
+need to make sure that the value is actually `null`, in which case we can conclude that the value can be explained
+as `REMOVED`.
 
-Similarly, if we encounter an operation that has written the expected value, we
-conclude that the value is `OBSERVED`. If there are any seeming inconsistencies
-between the model and resultset, we have to check whether or not the operation
-in question is still in flight. If it is, its results may still not be visible,
-so we can't reliably say it's an error.
+Similarly, if we encounter an operation that has written the expected value, we conclude that the value is `OBSERVED`.
+If there are any seeming inconsistencies between the model and resultset, we have to check whether or not the operation
+in question is still in flight. If it is, its results may still not be visible, so we can't reliably say it's an error.
 
-To summarize, in order for us to implement an exhaustive checker, we have to
-iterate operations for each of the rows present in the model in reverse order
-until we either detect inconsistency that can't be explained by an in-flight
+To summarize, in order for us to implement an exhaustive checker, we have to iterate operations for each of the rows
+present in the model in reverse order until we either detect inconsistency that can't be explained by an in-flight
 operation or until we explain every value in the row.
-
 
 ## Conclusion
 
-As you can see, all checkers up till now are almost entirely stateless.
-Exhaustive and quiescent models rely on `DataTracker` component that is aware of
-the in-flight and completed `lts`, but don't need any other state apart from
-that, since we can always inflate a complete partition from scratch every time
-we validate.
+As you can see, all checkers up till now are almost entirely stateless. Exhaustive and quiescent models rely
+on `DataTracker` component that is aware of the in-flight and completed `lts`, but don't need any other state apart from
+that, since we can always inflate a complete partition from scratch every time we validate.
 
-While not relying on the state is a useful feature, at least _some_ state is
-useful to have. For example, if we're validating just a few rows in the
-partition, right now we have to iterate through each and every `lts` that has
-visited this partition and filter out only modifications that have visited it.
-However, since the model is notified of each _started_, and, later, finished
-modification via `recordEvent`, we can keep track of `pd -> (cd -> lts)` map.
-You can check out `VisibleRowsChecker` as an example of that.
+While not relying on the state is a useful feature, at least _some_ state is useful to have. For example, if we're
+validating just a few rows in the partition, right now we have to iterate through each and every `lts` that has visited
+this partition and filter out only modifications that have visited it. However, since the model is notified of each
+_started_, and, later, finished modification via `recordEvent`, we can keep track of `pd -> (cd -> lts)` map. You can
+check out `VisibleRowsChecker` as an example of that.
 
 # Usage
 
-To use Harry, you first need to build a Cassandra in-JVM dtest jar. At the moment
-of writing, there's no official repository where these jars are released, so you'll
-have to build it manually:
+To use Harry, you first need to build a Cassandra in-JVM dtest jar. At the moment of writing, there's no official
+repository where these jars are released, so you'll have to build it manually (_*TODO: Make this simpler!*_):
 
 ```
 make package
@@ -760,23 +751,20 @@ cd ~/../harry/
 make run
 ```
 
-For best effect, uncomment `scheduleCorruption(run, executor);` in `HarryRunner`, which
-will corrupt data in some way so that you could see how Harry detects this corruption.
+To see how Harry detects corruption, uncomment `scheduleCorruption(run, executor);` in `HarryRunner`, which will corrupt
+data in some way.
 
-Each Harry failure contains a complete cluster state, operation log, failure
-description, and a run configuration. Most of the time, you'll be able to just load
-up the existing cluster state with `harry.runner.Reproduce` class, which pick up
-a run configuration from `shared/run.yml`, and see the same error you've seen
-in your failure log.
+Each Harry failure contains a complete cluster state, operation log, failure description, and a run configuration. Most
+of the time, you'll be able to just load up the existing cluster state with `harry.runner.Reproduce` class, which pick
+up a run configuration from `shared/run.yml`, and see the same error you've seen in your failure log.
 
-When reproducing, make sure to point `system_under_test/root` in the yaml
-file to the dump, which is something like `~/harry/shared/cluster-state/1599155256261`,
-and make sure to point validation to the same LTS as the failed one with
-`run.validator.validatePartition(...L)`.
+When reproducing, make sure to point `system_under_test/root` in the yaml file to the dump, which is something
+like `~/harry/shared/cluster-state/1599155256261`, and make sure to point validation to the same LTS as the failed one
+with `run.validator.validatePartition(...L)`.
 
-Because of how our corruptor works, some errors are only reproducible on a specific
-lts, since they're kind of writing the data "from the future", so you should also make
-sure you set the following values from the corresponding values in `failure.dump`.
+Because of how our corruptor works, some errors are only reproducible on a specific lts, since they're kind of writing
+the data "from the future", so you should also make sure you set the following values from the corresponding values
+in `failure.dump`.
 
 ```
 model:
@@ -785,34 +773,6 @@ model:
     max_complete_lts: your_value
 ```
 
-# What's missing
-
-Harry is by no means feature-complete. Main things that are missing are:
-
-  * Some types (such as collections) are not deflatable
-  * Some types are implemented, but are not hooked up (`blob` and `text`) to DSL/generator
-  * 2i queries are not implemented
-  * Compact storage is not implemented
-  * Fault injection is not implemented
-  * Runner and scheduler are rather rudimentary and require significant rework and proper scheduling
-  * TTL is not supported
-  * Some SELECT queries are not supported: `LIMIT`, `IN`, `GROUP BY`, token range queries
-  * Pagination is not implemented
-
-Some things, even though are implemented, can be improved or optimized:
-
-  * RNG should be able to yield less than 64 bits of entropy per step
-  * State tracking should be done in a compact off-heap data stucture
-  * Inflated partition state and per-row operation log should be done in a compact
-  off-heap data structure
-  * Exhaustive checker can be significantly optimized
-  * Exhaustive checker should use more precise information from data tracker, not
-  just watermarks
-  * Decision-making about _when_ we visit partitions and/or rows should be improved
-
-This list of improvements is incomplete, and should only give the reader a rough
-idea about the state of the project. Main goal for the initial release was to make it
-useful, now we can make it fast and feature-complete!
 
 # How to cut a release
 
@@ -851,27 +811,24 @@ mvn release:perform
 ```
 
 2. Close staging repository: https://repository.apache.org/#stagingRepositories
-3. Issue a vote on developers mailing list. Add your GPG key signature, release SHA, and staged artifacts to release information.
+3. Issue a vote on developers mailing list. Add your GPG key signature, release SHA, and staged artifacts to release
+   information.
 
 # Contributors
 
-  * [Alex Petrov](https://github.com/ifesdjeen)
-  * [Benedict Elliot Smith](https://github.com/belliottsmith)
+* [Alex Petrov](https://github.com/ifesdjeen)
+* [Benedict Elliot Smith](https://github.com/belliottsmith)
 
-Special thanks to [Aleksey Yeschenko](https://github.com/iamaleksey),
-[Sam Tunnicliffe](https://github.com/beobal), [Marcus Eriksson](https://github.com/krummas),
+Special thanks
+to [Aleksey Yeschenko](https://github.com/iamaleksey), [Sam Tunnicliffe](https://github.com/beobal), [Marcus Eriksson](https://github.com/krummas),
 and [Scott Andreas](https://github.com/cscotta).
 
 # License
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "
+AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.

--- a/bin/build-cassandra-submodule.sh
+++ b/bin/build-cassandra-submodule.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#!/usr/bin/env bash
+
+set -e
+
+cd cassandra/
+# Build the dtest JAR
+./build-shaded-dtest-jar.sh
+
+# Build the normal JAR
+ant
+cd -

--- a/conf/example.yaml
+++ b/conf/example.yaml
@@ -44,30 +44,27 @@ schema_provider:
 # be taken to map a real-time timestamp from the value retrieved from the database in order
 # to map it back to the logical timestamp of the operation that wrote this value.
 clock:
-  approximate_monotonic:
-    history_size: 7300
-    epoch_length: 1
-    epoch_time_unit: "SECONDS"
+  offset:
+    offset: 1000
 
 drop_schema: false
 create_schema: true
 truncate_table: true
 
-# System under test: a Cassandra node or cluster. Default implementation is in_jvm (in-jvm DTest cluster).
-# Harry also supports external clusters.
-system_under_test:
-  external:
-    contact_points: 127.0.0.1
-    port: 9042
-    username: null
-    password: null
-    # Use ONE for a single-node local Cassandra cluster, use QUORUM for larger clusters
-    consistency_level: ONE
-
 # Partition descriptor selector controls how partitions is selected based on the current logical
 # timestamp. Default implementation is a sliding window of partition descriptors that will visit
 # one partition after the other in the window `slide_after_repeats` times. After that will
 # retire one partition descriptor, and pick one instead of it.
+#
+# If you are running more than one Harry instance against the keyspace, you want to set `position_offset`,
+# which ensures that next runner will not intersect with a current one. For example, if you expect
+# this runner to visit less than 1M partitions over ~10*100*1M LTS, set other runner's offset to 1M.
+#
+# When doing so, we advise to also set `position_window_size` to make sure your runner exits before it
+# crosses into the other runner's partition space.
+#
+# Optionally, you can just configure `total_runners`, a number of runners you are about to set up, and
+# `runner_index`, an index of the current runner.
 partition_descriptor_selector:
   default:
     window_size: 10
@@ -86,12 +83,12 @@ clustering_descriptor_selector:
       type: "constant"
       constant: 2
     operation_kind_weights:
-      DELETE_RANGE: 1
-      DELETE_SLICE: 1
-      DELETE_ROW: 1
-      DELETE_COLUMN: 1
-      DELETE_PARTITION: 1
-      DELETE_COLUMN_WITH_STATICS: 1
+      DELETE_RANGE: 0
+      DELETE_SLICE: 0
+      DELETE_ROW: 0
+      DELETE_COLUMN: 0
+      DELETE_PARTITION: 0
+      DELETE_COLUMN_WITH_STATICS: 0
       INSERT_WITH_STATICS: 50
       INSERT: 50
       UPDATE_WITH_STATICS: 50
@@ -99,34 +96,10 @@ clustering_descriptor_selector:
     column_mask_bitsets: null
     max_partition_size: 1000
 
-# Runner is a is a component that schedules operations that change the cluster (system under test)
-# and model state.
-runner:
-  sequential:
-    run_time: 2
-    run_time_unit: "HOURS"
-
-    visitors:
-      - logging:
-          row_visitor:
-            mutating: {}
-      - sampler:
-          sample_partitions: 10
-      - parallel_validate_recent_partitions:
-          partition_count: 100
-          queries_per_partition: 2
-          concurrency: 20
-          model:
-            quiescent_checker: {}
-      - validate_all_partitions:
-          concurrency: 20
-          model:
-            quiescent_checker: {}
-
 metric_reporter:
   no_op: {}
 
+# Data tracker keeps track of in-progress and finished sequences. If you are using
+# a concurrent runner with both readers and writers, you want to use a `locking` tracker.
 data_tracker:
-  locking:
-    max_seen_lts: -1
-    max_complete_lts: -1
+  default: {}

--- a/harry-core/src/harry/model/RepairingLocalStateValidator.java
+++ b/harry-core/src/harry/model/RepairingLocalStateValidator.java
@@ -57,7 +57,6 @@ public class RepairingLocalStateValidator extends AllPartitionsValidator
     {
         super(run, concurrency, modelFactory, queryLogger);
         this.inJvmSut = (InJvmSut) run.sut;
-        OpSelectors.MonotonicClock clock = run.clock;
     }
 
     public void visit()

--- a/harry-core/src/harry/model/sut/TokenPlacementModel.java
+++ b/harry-core/src/harry/model/sut/TokenPlacementModel.java
@@ -20,53 +20,95 @@ package harry.model.sut;
 
 import java.net.InetAddress;
 import java.util.*;
+import java.util.function.Function;
+
+import static harry.model.sut.TokenPlacementModel.NtsReplicationFactor.assertStrictlySorted;
 
 public class TokenPlacementModel
 {
-    /**
-     * Replicate ranges to rf nodes.
-     */
-    public static NavigableMap<Range, List<Node>> replicate(List<Node> nodes, int rf)
+    public abstract static class ReplicationFactor
     {
-        nodes.sort(Node::compareTo);
-        List<Range> ranges = toRanges(nodes);
-        return replicate(ranges, nodes, rf);
-    }
+        private final int nodesTotal;
 
-    public static List<Node> getReplicas(NavigableMap<TokenPlacementModel.Range, List<TokenPlacementModel.Node>> ring, long token)
-    {
-        return ring.get(ring.floorKey(new Range(token, token, true)));
-    }
-
-    public static NavigableMap<Range, List<Node>> replicate(List<Range> ranges, List<Node> nodes, int rf)
-    {
-        NavigableMap<Range, List<Node>> replication = new TreeMap<>();
-        for (Range range : ranges)
+        public ReplicationFactor(int total)
         {
-            Set<String> names = new HashSet<>();
-            List<Node> replicas = new ArrayList<>();
-            int idx = primaryReplica(nodes, range);
-            if (idx >= 0)
-            {
-                for (int i = idx; i < nodes.size() && replicas.size() < rf; i++)
-                    addIfUnique(replicas, names, nodes.get(i));
-
-                for (int i = 0; replicas.size() < rf && i < idx; i++)
-                    addIfUnique(replicas, names, nodes.get(i));
-                if (range.start == Long.MIN_VALUE)
-                    replication.put(ranges.get(ranges.size() - 1), replicas);
-                replication.put(range, replicas);
-            }
-            else
-            {
-                // if the range end is larger than the highest assigned token, then treat it
-                // as part of the wraparound and replicate it to the same nodes as the first
-                // range. This is most likely caused by a decommission removing the node with
-                // the largest token.
-                replication.put(range, replication.get(ranges.get(0)));
-            }
+            this.nodesTotal = total;
         }
-        return replication;
+
+        public int total()
+        {
+            return nodesTotal;
+        }
+
+        public abstract Map<String, Integer> asMap();
+        public abstract int dcs();
+
+        public final ReplicatedRanges replicate(List<Node> nodes)
+        {
+            assertStrictlySorted(nodes);
+            return replicate(toRanges(nodes), nodes);
+        }
+
+        public abstract ReplicatedRanges replicate(Range[] ranges, List<Node> nodes);
+    }
+
+    public static class ReplicatedRanges
+    {
+        private final Range[] ranges;
+        private final NavigableMap<Range, List<Node>> placementsForRange;
+
+        public ReplicatedRanges(Range[] ranges, NavigableMap<Range, List<Node>> placementsForRange)
+        {
+            this.ranges = ranges;
+            this.placementsForRange = placementsForRange;
+        }
+
+        public List<Node> replicasFor(long token)
+        {
+            int idx = indexedBinarySearch(ranges, range -> {
+                // exclusive start, so token at the start belongs to a lower range
+                if (token <= range.start)
+                    return 1;
+                // ie token > start && token <= end
+                if (token <= range.end ||range.end == Long.MIN_VALUE)
+                    return 0;
+
+                return -1;
+            });
+            assert idx >= 0 : String.format("Somehow ranges %s do not contain token %d", Arrays.toString(ranges), token);
+            return placementsForRange.get(ranges[idx]);
+        }
+
+        public NavigableMap<Range, List<Node>> asMap()
+        {
+            return placementsForRange;
+        }
+
+        private static <T> int indexedBinarySearch(T[] arr, CompareTo<T> comparator)
+        {
+            int low = 0;
+            int high = arr.length - 1;
+
+            while (low <= high)
+            {
+                int mid = (low + high) >>> 1;
+                T midEl = arr[mid];
+                int cmp = comparator.compareTo(midEl);
+
+                if (cmp < 0)
+                    low = mid + 1;
+                else if (cmp > 0)
+                    high = mid - 1;
+                else
+                    return mid;
+            }
+            return -(low + 1); // key not found
+        }
+    }
+
+    public interface CompareTo<V>
+    {
+        int compareTo(V v);
     }
 
     public static void addIfUnique(List<Node> nodes, Set<String> names, Node node)
@@ -93,27 +135,25 @@ public class TokenPlacementModel
     /**
      * Generates token ranges from the list of nodes
      */
-    public static List<Range> toRanges(List<Node> nodes)
+    public static Range[] toRanges(List<Node> nodes)
     {
         List<Long> tokens = new ArrayList<>();
         for (Node node : nodes)
-        {
-            if (node.token != Long.MIN_VALUE)
-                tokens.add(node.token);
-        }
+            tokens.add(node.token);
         tokens.add(Long.MIN_VALUE);
         tokens.sort(Long::compareTo);
 
-        List<Range> ranges = new ArrayList<>(tokens.size() + 1);
+        Range[] ranges = new Range[nodes.size() + 1];
         long prev = tokens.get(0);
+        int cnt = 0;
         for (int i = 1; i < tokens.size(); i++)
         {
             long current = tokens.get(i);
-            ranges.add(new Range(prev, current));
+            ranges[cnt++] = new Range(prev, current);
             prev = current;
         }
-        ranges.add(new Range(prev, Long.MIN_VALUE));
-        return Collections.unmodifiableList(ranges);
+        ranges[ranges.length - 1] = new Range(prev, Long.MIN_VALUE);
+        return ranges;
     }
 
     public static List<Node> peerStateToNodes(Object[][] resultset)
@@ -123,10 +163,325 @@ public class TokenPlacementModel
         {
             InetAddress address = (InetAddress) row[0];
             Set<String> tokens = (Set<String>) row[1];
+            String dc = (String) row[2];
+            String rack = (String) row[3];
             for (String token : tokens)
-                nodes.add(new Node(Long.parseLong(token), address.toString()));
+                nodes.add(new Node(Long.parseLong(token), address.toString(), new Location(dc, rack)));
         }
         return nodes;
+    }
+
+    public static class NtsReplicationFactor extends ReplicationFactor
+    {
+        private final Map<String, Integer> map;
+
+        public NtsReplicationFactor(int... nodesPerDc)
+        {
+            this("datacenter", nodesPerDc);
+        }
+        public NtsReplicationFactor(String prefix, int... nodesPerDc)
+        {
+            super(total(nodesPerDc));
+            this.map = new HashMap<>();
+            for (int i = 0; i < nodesPerDc.length; i++)
+                map.put(prefix + (i + 1), nodesPerDc[i]);
+        }
+
+        public NtsReplicationFactor(Map<String, Integer> m)
+        {
+            super(m.values().stream().reduce(0, Integer::sum));
+            this.map = m;
+        }
+
+        private static int total(int... num)
+        {
+            int tmp = 0;
+            for (int i : num)
+                tmp += i;
+            return tmp;
+        }
+
+        public Map<String, Integer> asMap()
+        {
+            return new TreeMap<>(map);
+        }
+
+        public int dcs()
+        {
+            return map.size();
+        }
+
+        public ReplicatedRanges replicate(Range[] ranges, List<Node> nodes)
+        {
+            return replicate(ranges, nodes, map);
+        }
+
+        public static <T extends Comparable<T>> void assertStrictlySorted(Collection<T> coll)
+        {
+            if (coll.size() <= 1) return;
+
+            Iterator<T> iter = coll.iterator();
+            T prev = iter.next();
+            while (iter.hasNext())
+            {
+                T next = iter.next();
+                assert next.compareTo(prev) > 0 : String.format("Collection does not seem to be sorted. %s and %s are in wrong order", prev, next);
+                prev = next;
+            }
+        }
+        public static ReplicatedRanges replicate(Range[] ranges, List<Node> nodes, Map<String, Integer> rfs)
+        {
+            Map<String, DatacenterNodes> template = new HashMap<>();
+
+            Map<String, List<Node>> nodesByDC = nodesByDC(nodes);
+            Map<String, Set<String>> racksByDC = racksByDC(nodes);
+
+            for (Map.Entry<String, Integer> entry : rfs.entrySet())
+            {
+                String dc = entry.getKey();
+                int rf = entry.getValue();
+                List<Node> nodesInThisDC = nodesByDC.get(dc);
+                Set<String> racksInThisDC = racksByDC.get(dc);
+                int nodeCount = nodesInThisDC == null ? 0 : nodesInThisDC.size();
+                int rackCount = racksInThisDC == null ? 0 : racksInThisDC.size();
+                if (rf <= 0 || nodeCount == 0)
+                    continue;
+
+                template.put(dc, new DatacenterNodes(rf, rackCount, nodeCount));
+            }
+
+            NavigableMap<Range, Map<String, List<Node>>> replication = new TreeMap<>();
+
+            for (Range range : ranges)
+            {
+                final int idx = primaryReplica(nodes, range);
+                int cnt = 0;
+                if (idx >= 0)
+                {
+                    int dcsToFill = template.size();
+
+                    Map<String, DatacenterNodes> nodesInDCs = new HashMap<>();
+                    for (Map.Entry<String, DatacenterNodes> e : template.entrySet())
+                        nodesInDCs.put(e.getKey(), e.getValue().copy());
+
+                    while (dcsToFill > 0 && cnt < nodes.size())
+                    {
+                        Node node = nodes.get((idx + cnt) % nodes.size());
+                        DatacenterNodes dcNodes = nodesInDCs.get(node.location.dc);
+                        if (dcNodes != null && dcNodes.addAndCheckIfDone(node, new Location(node.location.dc, node.location.rack)))
+                            dcsToFill--;
+
+                        cnt++;
+                    }
+
+                    replication.put(range, mapValues(nodesInDCs, v -> v.nodes));
+                }
+                else
+                {
+                    // if the range end is larger than the highest assigned token, then treat it
+                    // as part of the wraparound and replicate it to the same nodes as the first
+                    // range. This is most likely caused by decommission removing the node with
+                    // the largest token.
+                    replication.put(range, replication.get(ranges[0]));
+                }
+            }
+
+            return combine(replication);
+        }
+
+        private static ReplicatedRanges combine(NavigableMap<Range, Map<String, List<Node>>> orig)
+        {
+
+            Range[] ranges = new Range[orig.size()];
+            int idx = 0;
+            NavigableMap<Range, List<Node>> flattened = new TreeMap<>();
+            for (Map.Entry<Range, Map<String, List<Node>>> e : orig.entrySet())
+            {
+                List<Node> placementsForRange = new ArrayList<>();
+                for (List<Node> v : e.getValue().values())
+                    placementsForRange.addAll(v);
+                ranges[idx++] = e.getKey();
+                flattened.put(e.getKey(), placementsForRange);
+            }
+            return new ReplicatedRanges(ranges, flattened);
+        }
+
+        public String toString()
+        {
+            return "NtsReplicationFactor{" +
+                   ", map=" + map +
+                   '}';
+        }
+    }
+
+    private static final class DatacenterNodes
+    {
+        private final List<Node> nodes = new ArrayList<>();
+        private final Set<Location> racks = new HashSet<>();
+
+        /** Number of replicas left to fill from this DC. */
+        int rfLeft;
+        int acceptableRackRepeats;
+
+        public DatacenterNodes copy()
+        {
+            return new DatacenterNodes(rfLeft, acceptableRackRepeats);
+        }
+
+        DatacenterNodes(int rf,
+                        int rackCount,
+                        int nodeCount)
+        {
+            this.rfLeft = Math.min(rf, nodeCount);
+            acceptableRackRepeats = rf - rackCount;
+        }
+
+        // for copying
+        DatacenterNodes(int rfLeft, int acceptableRackRepeats)
+        {
+            this.rfLeft = rfLeft;
+            this.acceptableRackRepeats = acceptableRackRepeats;
+        }
+
+        boolean addAndCheckIfDone(Node node, Location location)
+        {
+            if (done())
+                return false;
+
+            if (nodes.contains(node))
+                // Cannot repeat a node.
+                return false;
+
+            if (racks.add(location))
+            {
+                // New rack.
+                --rfLeft;
+                nodes.add(node);
+                return done();
+            }
+            if (acceptableRackRepeats <= 0)
+                // There must be rfLeft distinct racks left, do not add any more rack repeats.
+                return false;
+
+            nodes.add(node);
+
+            // Added a node that is from an already met rack to match RF when there aren't enough racks.
+            --acceptableRackRepeats;
+            --rfLeft;
+            return done();
+        }
+
+        boolean done()
+        {
+            assert rfLeft >= 0;
+            return rfLeft == 0;
+        }
+    }
+
+    public static class Location
+    {
+        public final String dc;
+        public final String rack;
+
+        public Location(String dc, String rack)
+        {
+            this.dc = dc;
+            this.rack = rack;
+        }
+    }
+
+    private static <K extends Comparable<K>, T1, T2> Map<K, T2> mapValues(Map<K, T1> allDCs, Function<T1, T2> map)
+    {
+        NavigableMap<K, T2> res = new TreeMap<>();
+        for (Map.Entry<K, T1> e : allDCs.entrySet())
+        {
+            res.put(e.getKey(), map.apply(e.getValue()));
+        }
+        return res;
+    }
+
+    public static Map<String, List<Node>> nodesByDC(List<Node> nodes)
+    {
+        Map<String, List<Node>> nodesByDC = new HashMap<>();
+        for (Node node : nodes)
+            nodesByDC.computeIfAbsent(node.location.dc, (k) -> new ArrayList<>()).add(node);
+
+        return nodesByDC;
+    }
+
+    public static Map<String, Integer> dcLayout(List<Node> nodes)
+    {
+        Map<String, List<Node>> nodesByDC = nodesByDC(nodes);
+        Map<String, Integer> layout = new HashMap<>();
+        for (Map.Entry<String, List<Node>> e : nodesByDC.entrySet())
+            layout.put(e.getKey(), e.getValue().size());
+
+        return layout;
+    }
+
+    public static Map<String, Set<String>> racksByDC(List<Node> nodes)
+    {
+        Map<String, Set<String>> racksByDC = new HashMap<>();
+        for (Node node : nodes)
+            racksByDC.computeIfAbsent(node.location.dc, (k) -> new HashSet<>()).add(node.location.rack);
+
+        return racksByDC;
+    }
+
+
+    public static class SimpleReplicationFactor extends ReplicationFactor
+    {
+        public SimpleReplicationFactor(int total)
+        {
+            super(total);
+        }
+
+        public Map<String, Integer> asMap()
+        {
+            return Collections.singletonMap("datacenter1", total());
+        }
+
+        public int dcs()
+        {
+            return 1;
+        }
+
+        public ReplicatedRanges replicate(Range[] ranges, List<Node> nodes)
+        {
+            return replicate(ranges, nodes, total());
+        }
+
+        public static ReplicatedRanges replicate(Range[] ranges, List<Node> nodes, int rf)
+        {
+            NavigableMap<Range, List<Node>> replication = new TreeMap<>();
+            for (Range range : ranges)
+            {
+                Set<String> names = new HashSet<>();
+                List<Node> replicas = new ArrayList<>();
+                int idx = primaryReplica(nodes, range);
+                if (idx >= 0)
+                {
+                    for (int i = idx; i < nodes.size() && replicas.size() < rf; i++)
+                        addIfUnique(replicas, names, nodes.get(i));
+
+                    for (int i = 0; replicas.size() < rf && i < idx; i++)
+                        addIfUnique(replicas, names, nodes.get(i));
+                    if (range.start == Long.MIN_VALUE)
+                        replication.put(ranges[ranges.length - 1], replicas);
+                    replication.put(range, replicas);
+                }
+                else
+                {
+                    // if the range end is larger than the highest assigned token, then treat it
+                    // as part of the wraparound and replicate it to the same nodes as the first
+                    // range. This is most likely caused by a decommission removing the node with
+                    // the largest token.
+                    replication.put(range, replication.get(ranges[0]));
+                }
+            }
+
+            return new ReplicatedRanges(ranges, Collections.unmodifiableNavigableMap(replication));
+        }
     }
 
     public static class Range implements Comparable<Range>
@@ -185,11 +540,13 @@ public class TokenPlacementModel
     {
         public final long token;
         public final String id;
+        public final Location location;
 
-        public Node(long token, String id)
+        public Node(long token, String id, Location location)
         {
             this.token = token;
             this.id = id;
+            this.location = location;
         }
 
         public boolean equals(Object o)

--- a/harry-core/src/harry/model/sut/injvm/InJVMTokenAwareVisitExecutor.java
+++ b/harry-core/src/harry/model/sut/injvm/InJVMTokenAwareVisitExecutor.java
@@ -20,7 +20,6 @@ package harry.model.sut.injvm;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NavigableMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -44,19 +43,18 @@ import org.apache.cassandra.distributed.api.ConsistencyLevel;
 import org.apache.cassandra.distributed.api.IInstance;
 
 import static harry.model.sut.TokenPlacementModel.peerStateToNodes;
-import static harry.model.sut.TokenPlacementModel.getReplicas;
 
 public class InJVMTokenAwareVisitExecutor extends LoggingVisitor.LoggingVisitorExecutor
 {
     private final InJvmSut sut;
-    private final int rf;
+    private final TokenPlacementModel.ReplicationFactor rf;
     private final SystemUnderTest.ConsistencyLevel cl;
     private final SchemaSpec schema;
     private final int MAX_RETRIES = 10;
 
     public static Function<Run, VisitExecutor> factory(OperationExecutor.RowVisitorFactory rowVisitorFactory,
                                                        SystemUnderTest.ConsistencyLevel cl,
-                                                       int rf)
+                                                       TokenPlacementModel.ReplicationFactor rf)
     {
         return (run) -> new InJVMTokenAwareVisitExecutor(run, rowVisitorFactory, cl, rf);
     }
@@ -64,7 +62,7 @@ public class InJVMTokenAwareVisitExecutor extends LoggingVisitor.LoggingVisitorE
     public InJVMTokenAwareVisitExecutor(Run run,
                                         OperationExecutor.RowVisitorFactory rowVisitorFactory,
                                         SystemUnderTest.ConsistencyLevel cl,
-                                        int rf)
+                                        TokenPlacementModel.ReplicationFactor rf)
     {
         super(run, rowVisitorFactory.make(run));
         this.sut = (InJvmSut) run.sut;
@@ -88,7 +86,7 @@ public class InJVMTokenAwareVisitExecutor extends LoggingVisitor.LoggingVisitorE
             throw new IllegalStateException(String.format("Can not execute statement %s after %d retries", statement, retries));
 
         Object[] pk =  schema.inflatePartitionKey(pd);
-        List<TokenPlacementModel.Node> replicas = getReplicas(getRing(), TokenUtil.token(ByteUtils.compose(ByteUtils.objectsToBytes(pk))));
+        List<TokenPlacementModel.Node> replicas = getRing().replicasFor(TokenUtil.token(ByteUtils.compose(ByteUtils.objectsToBytes(pk))));
 
         TokenPlacementModel.Node replica = replicas.get((int) (lts % replicas.size()));
         if (cl == SystemUnderTest.ConsistencyLevel.NODE_LOCAL)
@@ -114,14 +112,15 @@ public class InJVMTokenAwareVisitExecutor extends LoggingVisitor.LoggingVisitorE
         }
     }
 
-    protected NavigableMap<TokenPlacementModel.Range, List<TokenPlacementModel.Node>> getRing()
+    protected TokenPlacementModel.ReplicatedRanges getRing()
     {
-        List<TokenPlacementModel.Node> other = peerStateToNodes(sut.cluster.coordinator(1).execute("select peer, tokens from system.peers", ConsistencyLevel.ONE));
-        List<TokenPlacementModel.Node> self = peerStateToNodes(sut.cluster.coordinator(1).execute("select broadcast_address, tokens from system.local", ConsistencyLevel.ONE));
+        List<TokenPlacementModel.Node> other = peerStateToNodes(sut.cluster.coordinator(1).execute("select peer, tokens, data_center, rack from system.peers", ConsistencyLevel.ONE));
+        List<TokenPlacementModel.Node> self = peerStateToNodes(sut.cluster.coordinator(1).execute("select broadcast_address, tokens, data_center, rack from system.local", ConsistencyLevel.ONE));
         List<TokenPlacementModel.Node> all = new ArrayList<>();
         all.addAll(self);
         all.addAll(other);
-        return TokenPlacementModel.replicate(all, rf);
+        all.sort(TokenPlacementModel.Node::compareTo);
+        return rf.replicate(all);
     }
 
     protected Object[][] executeNodeLocal(String statement, TokenPlacementModel.Node node, Object... bindings)
@@ -154,7 +153,7 @@ public class InJVMTokenAwareVisitExecutor extends LoggingVisitor.LoggingVisitorE
         @Override
         public Visitor make(Run run)
         {
-            return new GeneratingVisitor(run, new InJVMTokenAwareVisitExecutor(run, row_visitor, consistency_level, rf));
+            return new GeneratingVisitor(run, new InJVMTokenAwareVisitExecutor(run, row_visitor, consistency_level, new TokenPlacementModel.SimpleReplicationFactor(rf)));
         }
     }
 }

--- a/harry-core/src/harry/reconciler/PartitionState.java
+++ b/harry-core/src/harry/reconciler/PartitionState.java
@@ -40,6 +40,8 @@ public class PartitionState implements Iterable<Reconciler.RowState>
     final long pd;
     final long debugCd;
     final SchemaSpec schema;
+    final List<Long> visitedLts = new ArrayList<>();
+    final List<Long> skippedLts = new ArrayList<>();
 
     // Collected state
     Reconciler.RowState staticRow;
@@ -254,6 +256,9 @@ public class PartitionState implements Iterable<Reconciler.RowState>
     public String toString(SchemaSpec schema)
     {
         StringBuilder sb = new StringBuilder();
+
+        sb.append("Visited LTS: " + visitedLts).append("\n");
+        sb.append("Skipped LTS: " + skippedLts).append("\n");
 
         if (staticRow != null)
             sb.append("Static row: " + staticRow.toString(schema)).append("\n");

--- a/harry-core/src/harry/reconciler/Reconciler.java
+++ b/harry-core/src/harry/reconciler/Reconciler.java
@@ -86,7 +86,7 @@ public class Reconciler
 
         class Processor extends VisitExecutor
         {
-            // Whether or not a partition deletion was encountered on this LTS.
+            // Whether a partition deletion was encountered on this LTS.
             private boolean hadPartitionDeletion = false;
             private final List<Ranges.Range> rangeDeletes = new ArrayList<>();
             private final List<ReplayingVisitor.Operation> writes = new ArrayList<>();
@@ -256,7 +256,14 @@ public class Reconciler
         while (currentLts <= maxStarted && currentLts >= 0)
         {
             if (tracker.isFinished(currentLts))
+            {
+                partitionState.visitedLts.add(currentLts);
                 visitor.visit(currentLts);
+            }
+            else
+            {
+                partitionState.skippedLts.add(currentLts);
+            }
 
             currentLts = pdSelector.nextLts(currentLts);
         }

--- a/harry-core/src/harry/runner/EarlyExitException.java
+++ b/harry-core/src/harry/runner/EarlyExitException.java
@@ -16,32 +16,12 @@
  *  limitations under the License.
  */
 
-package harry.model;
+package harry.runner;
 
-import harry.core.Run;
-import harry.operations.Query;
-
-public interface Model
+public class EarlyExitException extends RuntimeException
 {
-    long NO_TIMESTAMP = Long.MIN_VALUE;
-
-    void validate(Query query);
-
-    interface ModelFactory
+    public EarlyExitException(String e)
     {
-        Model make(Run run);
+        super(e);
     }
-
-    class ValidationException extends RuntimeException
-    {
-        public ValidationException(String trackerState, String partitionState, String observedState, String format, Object... objects)
-        {
-            super(String.format(format, objects) +
-                  "\nTracker state:\n" + trackerState +
-                  "\nPartition state:\n" + partitionState +
-                  "\nObserved state:\n" + observedState);
-        }
-    }
-
-
 }

--- a/harry-core/src/harry/visitors/AllPartitionsValidator.java
+++ b/harry-core/src/harry/visitors/AllPartitionsValidator.java
@@ -100,6 +100,7 @@ public class AllPartitionsValidator implements Visitor
         List<Throwable> errors = new CopyOnWriteArrayList<>();
 
         final long maxPosition = pdSelector.maxPosition(tracker.maxStarted());
+
         AtomicLong currentPosition = new AtomicLong();
         for (int i = 0; i < concurrency; i++)
         {
@@ -131,7 +132,7 @@ public class AllPartitionsValidator implements Visitor
 
         Runner.shutdown(threads::stream);
         if (!errors.isEmpty())
-            throw Runner.merge(errors);
+            Runner.mergeAndThrow(errors);
     }
 
     public void visit()

--- a/harry-core/src/harry/visitors/LoggingVisitor.java
+++ b/harry-core/src/harry/visitors/LoggingVisitor.java
@@ -66,10 +66,8 @@ public class LoggingVisitor extends GeneratingVisitor
         protected CompiledStatement operationInternal(long lts, long pd, long cd, long m, long opId, OpSelectors.OperationKind opType)
         {
             CompiledStatement statement = super.operationInternal(lts, pd, cd, m, opId, opType);
-
             log(String.format("LTS: %d. Pd %d. Cd %d. M %d. OpId: %d Statement %s\n",
                               lts, pd, cd, m, opId, statement));
-
             return statement;
         }
 

--- a/harry-core/test/harry/runner/LockingDataTrackerTest.java
+++ b/harry-core/test/harry/runner/LockingDataTrackerTest.java
@@ -18,9 +18,7 @@
 
 package harry.runner;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,7 +38,7 @@ import harry.model.OpSelectors;
 import static harry.concurrent.InfiniteLoopExecutor.Daemon.NON_DAEMON;
 import static harry.concurrent.InfiniteLoopExecutor.Interrupts.UNSYNCHRONIZED;
 import static harry.concurrent.InfiniteLoopExecutor.SimulatorSafe.SAFE;
-import static harry.runner.Runner.merge;
+import static harry.runner.Runner.mergeAndThrow;
 
 public class LockingDataTrackerTest
 {
@@ -114,7 +112,7 @@ public class LockingDataTrackerTest
 
         interrupt.await(1, TimeUnit.MINUTES);
         if (!errors.isEmpty())
-            throw merge(errors);
+            Runner.mergeAndThrow(errors);
     }
     enum State { UNLOCKED, LOCKED_FOR_READ, LOCKED_FOR_WRITE }
 }

--- a/harry-examples/pom.xml
+++ b/harry-examples/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.apache.cassandra</groupId>
+        <version>0.0.2-SNAPSHOT</version>
+        <artifactId>harry-parent</artifactId>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>harry-core</artifactId>
+            <version>0.0.2-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>harry-integration-external</artifactId>
+            <version>0.0.2-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>harry-integration</artifactId>
+            <version>0.0.2-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    <name>Harry Examples</name>
+    <artifactId>harry-examples</artifactId>
+    <version>0.0.2-SNAPSHOT</version>
+
+    <scm>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/cassandra-harry.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/cassandra-harry.git</developerConnection>
+        <url>https://gitbox.apache.org/repos/asf/cassandra-harry.git</url>
+        <tag>0.0.1</tag>
+    </scm>
+</project>

--- a/harry-examples/src/harry/examples/Basic.java
+++ b/harry-examples/src/harry/examples/Basic.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package harry.examples;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import harry.core.Configuration;
+import harry.model.OpSelectors;
+import harry.model.sut.SystemUnderTest;
+import harry.model.sut.external.ExternalClusterSut;
+import harry.model.sut.injvm.InJvmSutConfiguration;
+import harry.runner.HarryRunner;
+import harry.runner.external.HarryRunnerExternal;
+import harry.visitors.MutatingRowVisitor;
+import harry.visitors.ParallelRecentValidator;
+import harry.visitors.QueryLogger;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This is a basic example of Harry running against an in-JVM cluster.
+ *
+ * To run, you'll need to add module visibility VM options (--add-opens and --add-exports) from harry-parent's POM.
+ */
+public class Basic
+{
+    public static void main(String[] args) throws Throwable
+    {
+        HarryRunner runner = new HarryRunnerExternal();
+        Configuration config = Configurations.IN_JVM;
+        runner.run(config);
+    }
+
+    public static class Configurations
+    {
+        public static Configuration IN_JVM = new Configuration.ConfigurationBuilder()
+                .setSeed(1L)
+                .setSchemaProvider(new Configuration.DefaultSchemaProviderConfiguration())
+                .setDropSchema(false)
+                .setCreateSchema(true)
+                .setTruncateTable(false)
+                .setClock(new Configuration.ApproximateMonotonicClockConfiguration(7300, 1, TimeUnit.SECONDS))
+                .setSUT(new InJvmSutConfiguration(3, 10, "/tmp/harry"))
+                .setPartitionDescriptorSelector(new Configuration.DefaultPDSelectorConfiguration(10, 100))
+                .setClusteringDescriptorSelector(
+                        new Configuration.DefaultCDSelectorConfiguration(
+                                new Configuration.ConstantDistributionConfig(4),
+                                new Configuration.ConstantDistributionConfig(2),
+                                1000,
+                                ImmutableMap.<OpSelectors.OperationKind, Integer>builder()
+                                        .put(OpSelectors.OperationKind.DELETE_RANGE, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_SLICE, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_ROW, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_COLUMN, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_PARTITION, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_COLUMN_WITH_STATICS, 1)
+                                        .put(OpSelectors.OperationKind.INSERT_WITH_STATICS, 50)
+                                        .put(OpSelectors.OperationKind.INSERT, 50)
+                                        .put(OpSelectors.OperationKind.UPDATE_WITH_STATICS, 50)
+                                        .put(OpSelectors.OperationKind.UPDATE, 50)
+                                        .build(),
+                                null))
+                .setRunner(new Configuration.SequentialRunnerConfig(ImmutableList.of(
+                            new Configuration.LoggingVisitorConfiguration(MutatingRowVisitor::new),
+                            new ParallelRecentValidator.ParallelRecentValidatorConfig(100, 20, 10_000, new Configuration.QuiescentCheckerConfig(), QueryLogger.NoOpQueryLogger::new),
+                            new Configuration.AllPartitionsValidatorConfiguration(20, new Configuration.QuiescentCheckerConfig(), QueryLogger.NoOpQueryLogger::new)
+                        ),
+                        5,
+                        TimeUnit.MINUTES
+                ))
+                .setDataTracker(new Configuration.DefaultLockingDataTrackerConfiguration())
+                .setMetricReporter(new Configuration.NoOpMetricReporterConfiguration())
+                .build();
+
+        @SuppressWarnings("unused") // reference
+        public static Configuration LOCAL_EXTERNAL = new Configuration.ConfigurationBuilder()
+                .setSeed(1L)
+                .setSchemaProvider(new Configuration.FixedSchemaProviderConfiguration(
+                        "harry",
+                        "test_table",
+                        ImmutableMap.of(
+                                "pk1", "bigint",
+                                "pk2", "ascii"),
+                        ImmutableMap.of(
+                                "ck1", "ascii",
+                                "ck2", "bigint"),
+                        ImmutableMap.of(
+                                "v1", "ascii",
+                                "v2", "bigint",
+                                "v3", "ascii",
+                                "v4", "bigint"),
+                        ImmutableMap.of(
+                                "s1", "ascii",
+                                "s2", "bigint",
+                                "s3", "ascii",
+                                "s4", "bigint")
+                        ))
+                .setDropSchema(false)
+                .setCreateSchema(true)
+                .setTruncateTable(true)
+                .setClock(new Configuration.ApproximateMonotonicClockConfiguration(7300, 1, TimeUnit.SECONDS))
+                .setSUT(new ExternalClusterSut.ExternalSutConfiguration("127.0.0.1", 9042, null, null, SystemUnderTest.ConsistencyLevel.ONE.toString()))
+                .setPartitionDescriptorSelector(new Configuration.DefaultPDSelectorConfiguration(10, 100))
+                .setClusteringDescriptorSelector(
+                        new Configuration.DefaultCDSelectorConfiguration(
+                                new Configuration.ConstantDistributionConfig(4),
+                                new Configuration.ConstantDistributionConfig(2),
+                                1000,
+                                ImmutableMap.<OpSelectors.OperationKind, Integer>builder()
+                                        .put(OpSelectors.OperationKind.DELETE_RANGE, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_SLICE, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_ROW, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_COLUMN, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_PARTITION, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_COLUMN_WITH_STATICS, 1)
+                                        .put(OpSelectors.OperationKind.INSERT_WITH_STATICS, 50)
+                                        .put(OpSelectors.OperationKind.INSERT, 50)
+                                        .put(OpSelectors.OperationKind.UPDATE_WITH_STATICS, 50)
+                                        .put(OpSelectors.OperationKind.UPDATE, 50)
+                                        .build(),
+                                null))
+                .setRunner(new Configuration.SequentialRunnerConfig(ImmutableList.of(
+                        new Configuration.LoggingVisitorConfiguration(MutatingRowVisitor::new),
+                        new ParallelRecentValidator.ParallelRecentValidatorConfig(100, 20, 10_000, new Configuration.QuiescentCheckerConfig(), QueryLogger.NoOpQueryLogger::new),
+                        new Configuration.AllPartitionsValidatorConfiguration(20, new Configuration.QuiescentCheckerConfig(), QueryLogger.NoOpQueryLogger::new)
+                ),
+                        5,
+                        TimeUnit.MINUTES
+                ))
+                .setDataTracker(new Configuration.DefaultLockingDataTrackerConfiguration())
+                .setMetricReporter(new Configuration.NoOpMetricReporterConfiguration())
+                .build();
+    }
+}

--- a/harry-examples/src/harry/examples/Parallel.java
+++ b/harry-examples/src/harry/examples/Parallel.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package harry.examples;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import harry.core.Configuration;
+import harry.model.OpSelectors;
+import harry.model.sut.SystemUnderTest;
+import harry.model.sut.external.ExternalClusterSut;
+import harry.model.sut.injvm.InJvmSutConfiguration;
+import harry.runner.HarryRunner;
+import harry.runner.external.HarryRunnerExternal;
+import harry.visitors.MutatingRowVisitor;
+import harry.visitors.ParallelRecentValidator;
+import harry.visitors.QueryLogger;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This is an example of the parallel runner, where each Harry runner gets a subset of the PartitionDescriptor space.
+ *
+ * See run instructions in harry.examples.Basic.
+ */
+public class Parallel
+{
+    private static int PARALLELISM = 4;
+    private static SystemUnderTest SUT;
+
+
+    public static void main(String[] args) throws Throwable
+    {
+        SUT = new InJvmSutConfiguration(3, 10, "/tmp/harry").make();
+
+        for (int i = 0; i < PARALLELISM; i++)
+        {
+            HarryRunner runner = new HarryRunnerExternal();
+            Configuration config = Configurations.makeLocalParallelConfiguration(i, PARALLELISM);
+            runner.run(config);
+        }
+    }
+
+    public static class Configurations
+    {
+        private static Configuration.ConfigurationBuilder IN_JVM_PARALLEL = new Configuration.ConfigurationBuilder()
+                .setSeed(1L)
+                .setSchemaProvider(new Configuration.FixedSchemaProviderConfiguration(
+                        "harry",
+                        "test_table",
+                        ImmutableMap.of(
+                                "pk1", "bigint",
+                                "pk2", "ascii"),
+                        ImmutableMap.of(
+                                "ck1", "ascii",
+                                "ck2", "bigint"),
+                        ImmutableMap.of(
+                                "v1", "ascii",
+                                "v2", "bigint",
+                                "v3", "ascii",
+                                "v4", "bigint"),
+                        ImmutableMap.of(
+                                "s1", "ascii",
+                                "s2", "bigint",
+                                "s3", "ascii",
+                                "s4", "bigint")
+                        ))
+                .setDropSchema(false)
+                .setCreateSchema(true)
+                .setTruncateTable(true)
+                .setClock(new Configuration.ApproximateMonotonicClockConfiguration(7300, 1, TimeUnit.SECONDS))
+                .setSUT(() -> SUT)
+                // This is missing a PartitionDescriptorSelector, since that requires the parallel-worker-index, and
+                // total number of workers
+                .setClusteringDescriptorSelector(
+                        new Configuration.DefaultCDSelectorConfiguration(
+                                new Configuration.ConstantDistributionConfig(4),
+                                new Configuration.ConstantDistributionConfig(2),
+                                1000,
+                                ImmutableMap.<OpSelectors.OperationKind, Integer>builder()
+                                        .put(OpSelectors.OperationKind.DELETE_RANGE, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_SLICE, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_ROW, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_COLUMN, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_PARTITION, 1)
+                                        .put(OpSelectors.OperationKind.DELETE_COLUMN_WITH_STATICS, 1)
+                                        .put(OpSelectors.OperationKind.INSERT_WITH_STATICS, 50)
+                                        .put(OpSelectors.OperationKind.INSERT, 50)
+                                        .put(OpSelectors.OperationKind.UPDATE_WITH_STATICS, 50)
+                                        .put(OpSelectors.OperationKind.UPDATE, 50)
+                                        .build(),
+                                null))
+                .setRunner(new Configuration.SequentialRunnerConfig(ImmutableList.of(
+                        new Configuration.LoggingVisitorConfiguration(MutatingRowVisitor::new),
+                        new ParallelRecentValidator.ParallelRecentValidatorConfig(100, 20, 10_000, new Configuration.QuiescentCheckerConfig(), QueryLogger.NoOpQueryLogger::new),
+                        new Configuration.AllPartitionsValidatorConfiguration(20, new Configuration.QuiescentCheckerConfig(), QueryLogger.NoOpQueryLogger::new)
+                ),
+                        5,
+                        TimeUnit.MINUTES
+                ))
+                .setDataTracker(new Configuration.DefaultLockingDataTrackerConfiguration())
+                .setMetricReporter(new Configuration.NoOpMetricReporterConfiguration());
+
+        public static Configuration makeLocalParallelConfiguration(int workerIndex, int totalWorkers)
+        {
+            Configuration.DefaultPDSelectorConfiguration pdSelectorConfig = new Configuration.DefaultPDSelectorConfiguration(10, 100, (long) workerIndex, (long) totalWorkers, null, null);
+            return IN_JVM_PARALLEL.setPartitionDescriptorSelector(pdSelectorConfig).build();
+        }
+    }
+}

--- a/harry-integration-external/src/harry/runner/external/MiniStress.java
+++ b/harry-integration-external/src/harry/runner/external/MiniStress.java
@@ -25,11 +25,15 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import harry.core.Configuration;
 import harry.core.Run;
 import harry.model.Model;
 import harry.model.OpSelectors;
 import harry.model.QuiescentChecker;
+import harry.model.sut.SystemUnderTest;
 import harry.model.sut.external.QuiescentLocalStateChecker;
 import harry.operations.Query;
 import harry.runner.HarryRunner;
@@ -42,41 +46,43 @@ import harry.visitors.Visitor;
 
 public class MiniStress
 {
+    private static final Logger logger = LoggerFactory.getLogger(Logger.class);
+
     public static void main(String... args) throws Throwable
     {
         File configFile = HarryRunner.loadConfig(args);
         Configuration config = Configuration.fromFile(configFile);
 
         List<Configuration.VisitorPoolConfiguration> concurrentPools = new ArrayList<>();
+        List<Visitor.VisitorFactory> sequentialPools = new ArrayList<>();
+
         List<Visitor.VisitorFactory> postRunValidation = new ArrayList<>();
         int duration = 60_000;
         for (String arg : args)
         {
+            if (arg.startsWith("--write-and-log"))
+            {
+                assert sequentialPools.isEmpty();
+                int concurrency = Integer.parseInt(arg.split("=")[1]);
+                concurrentPools.add(new Configuration.VisitorPoolConfiguration("Writer", concurrency, new Configuration.LoggingVisitorConfiguration(new Configuration.MutatingRowVisitorConfiguration())));
+            }
             if (arg.startsWith("--write"))
             {
+                assert sequentialPools.isEmpty();
                 int concurrency = Integer.parseInt(arg.split("=")[1]);
                 concurrentPools.add(new Configuration.VisitorPoolConfiguration("Writer", concurrency, MutatingVisitor::new));
             }
             else if (arg.startsWith("--read"))
             {
+                assert sequentialPools.isEmpty();
                 int concurrency = Integer.parseInt(arg.split("=")[1]);
-                AtomicLong modifier = new AtomicLong(0);
-                concurrentPools.add(new Configuration.VisitorPoolConfiguration("Reader", concurrency, (r) -> {
-                    Model model = new QuiescentChecker(r);
-                    OpSelectors.DefaultPdSelector pdSelector = (OpSelectors.DefaultPdSelector) r.pdSelector;
-
-                    return () -> {
-                        // Wait until we have something to validate
-                        if (r.tracker.maxStarted() == 0)
-                            return;
-
-                        long randomPd = pdSelector.randomVisitedPd(r.tracker.maxStarted(), modifier.incrementAndGet(), r.schemaSpec);
-                        Query query = Query.selectPartition(r.schemaSpec, randomPd, true);
-                        model.validate(query);
-                        query = Query.selectPartition(r.schemaSpec, randomPd, false);
-                        model.validate(query);
-                    };
-                }));
+                concurrentPools.add(new Configuration.VisitorPoolConfiguration("Reader", concurrency, makeValidator()));
+            }
+            else if (arg.startsWith("--write-before-read"))
+            {
+                assert concurrentPools.isEmpty();
+                sequentialPools.add(MutatingVisitor::new);
+                sequentialPools.add(makeValidator());
             }
             else if (arg.startsWith("--duration"))
             {
@@ -106,10 +112,15 @@ public class MiniStress
         System.out.println(Configuration.toYamlString(config));
 
         int finalDuration = duration;
-        new Runner.ChainRunner(run, config,
-                               Arrays.asList((r, c) -> new Runner.ConcurrentRunner(r, c, concurrentPools, finalDuration, TimeUnit.MILLISECONDS),
-                                             (r, c) -> new Runner.SingleVisitRunner(r, c, postRunValidation)))
-        .run();
+
+        List<Configuration.RunnerConfiguration> runners = new ArrayList<>();
+        if (!concurrentPools.isEmpty())
+            runners.add((r, c) -> new Runner.ConcurrentRunner(r, c, concurrentPools, finalDuration, TimeUnit.MILLISECONDS));
+        if (!sequentialPools.isEmpty())
+            runners.add((r, c) -> new Runner.SequentialRunner(r, c, sequentialPools, finalDuration, TimeUnit.MILLISECONDS));
+        runners.add((r, c) -> new Runner.SingleVisitRunner(r, c, postRunValidation));
+
+        new Runner.ChainRunner(run, config, runners).run();
 
         run.sut.shutdown();
 
@@ -124,4 +135,25 @@ public class MiniStress
         System.exit(0);
     }
 
+    private static Configuration.VisitorConfiguration makeValidator()
+    {
+        AtomicLong modifier = new AtomicLong(0);
+        return (r) -> {
+            Model model = new QuiescentChecker(r);
+            OpSelectors.DefaultPdSelector pdSelector = (OpSelectors.DefaultPdSelector) r.pdSelector;
+
+            return () -> {
+                long mod = modifier.incrementAndGet();
+                // Wait until we have something to validate
+                if (mod % 10_000 == 0)
+                    logger.info("Validated {} times", mod);
+
+                long randomPd = pdSelector.randomVisitedPd(r.tracker.maxStarted(), mod, r.schemaSpec);
+                Query query = Query.selectPartition(r.schemaSpec, randomPd, true);
+                model.validate(query);
+                query = Query.selectPartition(r.schemaSpec, randomPd, false);
+                model.validate(query);
+            };
+        };
+    }
 }

--- a/harry-integration/test/conf/cassandra.yaml
+++ b/harry-integration/test/conf/cassandra.yaml
@@ -3,19 +3,23 @@
 # Consider the effects on 'o.a.c.i.s.LegacySSTableTest' before changing schemas in this file.
 #
 cluster_name: Test Cluster
-memtable_allocation_type: heap_buffers
+# memtable_allocation_type: heap_buffers
+memtable_allocation_type: offheap_objects
 commitlog_sync: batch
-commitlog_sync_batch_window_in_ms: 1.0
-commitlog_segment_size_in_mb: 5
+commitlog_segment_size: 5MiB
 commitlog_directory: build/test/cassandra/commitlog
+# commitlog_compression:
+# - class_name: LZ4Compressor
+cdc_raw_directory: build/test/cassandra/cdc_raw
+cdc_enabled: false
 hints_directory: build/test/cassandra/hints
 partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner
 listen_address: 127.0.0.1
-storage_port: 7010
-rpc_port: 9170
+storage_port: 7012
+ssl_storage_port: 17012
 start_native_transport: true
 native_transport_port: 9042
-column_index_size_in_kb: 4
+column_index_size: 4KiB
 saved_caches_directory: build/test/cassandra/saved_caches
 data_file_directories:
     - build/test/cassandra/data
@@ -23,11 +27,9 @@ disk_access_mode: mmap
 seed_provider:
     - class_name: org.apache.cassandra.locator.SimpleSeedProvider
       parameters:
-          - seeds: "127.0.0.1"
+          - seeds: "127.0.0.1:7012"
 endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch
 dynamic_snitch: true
-request_scheduler: org.apache.cassandra.scheduler.RoundRobinScheduler
-request_scheduler_id: keyspace
 server_encryption_options:
     internode_encryption: none
     keystore: conf/.keystore
@@ -36,9 +38,77 @@ server_encryption_options:
     truststore_password: cassandra
 incremental_backups: true
 concurrent_compactors: 4
-compaction_throughput_mb_per_sec: 0
+compaction_throughput: 0MiB/s
 row_cache_class_name: org.apache.cassandra.cache.OHCProvider
-row_cache_size_in_mb: 16
-enable_user_defined_functions: true
-enable_scripted_user_defined_functions: true
-enable_drop_compact_storage: true
+row_cache_size: 16MiB
+user_defined_functions_enabled: true
+scripted_user_defined_functions_enabled: false
+prepared_statements_cache_size: 1MiB
+corrupted_tombstone_strategy: exception
+stream_entire_sstables: true
+stream_throughput_outbound: 23841858MiB/s
+sasi_indexes_enabled: true
+materialized_views_enabled: true
+drop_compact_storage_enabled: true
+file_cache_enabled: true
+full_query_logging_options:
+  allow_nodetool_archive_command: true
+auto_hints_cleanup_enabled: true
+
+heap_dump_path: build/test
+dump_heap_on_uncaught_exception: false
+
+read_thresholds_enabled: true
+coordinator_read_size_warn_threshold: 1024KiB
+coordinator_read_size_fail_threshold: 4096KiB
+local_read_size_warn_threshold: 4096KiB
+local_read_size_fail_threshold: 8192KiB
+row_index_read_size_warn_threshold: 4096KiB
+row_index_read_size_fail_threshold: 8192KiB
+
+memtable:
+    configurations:
+        skiplist:
+            class_name: SkipListMemtable
+        trie:
+            class_name: TrieMemtable
+            parameters:
+                shards: 4
+        skiplist_sharded:
+            class_name: ShardedSkipListMemtable
+            parameters:
+                serialize_writes: false
+        skiplist_sharded_locking:
+            inherits: skiplist_sharded
+            parameters:
+                serialize_writes: true
+        skiplist_remapped:
+            inherits: skiplist
+        test_fullname:
+            class_name: org.apache.cassandra.db.memtable.TestMemtable
+        test_shortname:
+            class_name: TestMemtable
+            parameters:
+                skiplist: true  # note: YAML must interpret this as string, not a boolean
+        test_empty_class:
+            class_name: ""
+        test_missing_class:
+            parameters:
+        test_unknown_class:
+            class_name: NotExisting
+        test_invalid_param:
+            class_name: SkipListMemtable
+            parameters:
+                invalid: throw
+        test_invalid_extra_param:
+            inherits: test_shortname
+            parameters:
+                invalid: throw
+        test_invalid_factory_method:
+            class_name: org.apache.cassandra.cql3.validation.operations.CreateTest$InvalidMemtableFactoryMethod
+        test_invalid_factory_field:
+            class_name: org.apache.cassandra.cql3.validation.operations.CreateTest$InvalidMemtableFactoryField
+        test_memtable_metrics:
+            class_name: TrieMemtable
+# Note: keep the memtable configuration at the end of the file, so that the default mapping can be changed without
+# duplicating the whole section above.

--- a/harry-integration/test/conf/logback-dtest.xml
+++ b/harry-integration/test/conf/logback-dtest.xml
@@ -32,7 +32,7 @@
     </rollingPolicy>
 
     <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-      <maxFileSize>200MB</maxFileSize>
+      <maxFileSize>20MB</maxFileSize>
     </triggeringPolicy>
 
     <encoder>
@@ -68,7 +68,7 @@
 
   <logger name="org.apache.hadoop" level="WARN"/>
 
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="INSTANCEASYNCFILE" />
     <appender-ref ref="INSTANCESTDERR" />
     <appender-ref ref="INSTANCESTDOUT" />

--- a/harry-integration/test/harry/generators/DataGeneratorsIntegrationTest.java
+++ b/harry-integration/test/harry/generators/DataGeneratorsIntegrationTest.java
@@ -78,6 +78,14 @@ public class DataGeneratorsIntegrationTest extends CQLTester
 
         TestRunner.test(gen,
                         (schema) -> {
+                            try
+                            {
+                                schema.validate();
+                            }
+                            catch (AssertionError e)
+                            {
+                                return;
+                            }
                             createTable(schema.compile().cql());
 
                             Configuration.ConfigurationBuilder builder = Configuration.fromFile(getClass().getClassLoader().getResource("single_partition_test.yml").getFile())
@@ -123,7 +131,6 @@ public class DataGeneratorsIntegrationTest extends CQLTester
 
         public void shutdown()
         {
-            cleanup();
         }
 
         public void schemaChange(String statement)

--- a/harry-integration/test/harry/model/QuiescentLocalStateCheckerIntegrationTest.java
+++ b/harry-integration/test/harry/model/QuiescentLocalStateCheckerIntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import harry.core.Configuration;
 import harry.ddl.SchemaGenerators;
 import harry.ddl.SchemaSpec;
+import harry.model.sut.TokenPlacementModel;
 import harry.model.sut.injvm.InJvmSut;
 import harry.model.sut.injvm.InJvmSutBase;
 import harry.model.sut.injvm.QuiescentLocalStateChecker;
@@ -65,7 +66,7 @@ public class QuiescentLocalStateCheckerIntegrationTest extends ModelTestBase
 
             Runner.chain(config,
                          Runner.sequential(MutatingVisitor::new, 2, TimeUnit.SECONDS),
-                         Runner.single(AllPartitionsValidator.factoryForTests(1, QuiescentLocalStateChecker.factory(1))))
+                         Runner.single(AllPartitionsValidator.factoryForTests(1, QuiescentLocalStateChecker.factory(new TokenPlacementModel.SimpleReplicationFactor(1)))))
                   .run();
             break;
         }

--- a/harry-integration/test/harry/reconciler/SimpleReconcilerTest.java
+++ b/harry-integration/test/harry/reconciler/SimpleReconcilerTest.java
@@ -162,6 +162,7 @@ public class SimpleReconcilerTest extends IntegrationTestBase
                     query = Query.selectPartition(schema, pd, reverse);
 
                     QuiescentChecker.validate(schema,
+                                              run.tracker,
                                               subset,
                                               state.state.get(pd),
                                               SelectHelper.execute(sut, run.clock, query, subset),
@@ -169,6 +170,7 @@ public class SimpleReconcilerTest extends IntegrationTestBase
 
                     query = Query.singleClustering(schema, pd, cd1, false);
                     QuiescentChecker.validate(schema,
+                                              run.tracker,
                                               subset,
                                               state.state.get(pd).apply(query),
                                               SelectHelper.execute(sut, run.clock, query, subset),
@@ -188,6 +190,7 @@ public class SimpleReconcilerTest extends IntegrationTestBase
                             }
 
                             QuiescentChecker.validate(schema,
+                                                      run.tracker,
                                                       subset,
                                                       state.state.get(pd).apply(query),
                                                       SelectHelper.execute(sut, run.clock, query, subset),
@@ -208,6 +211,7 @@ public class SimpleReconcilerTest extends IntegrationTestBase
                                 continue;
                             }
                             QuiescentChecker.validate(schema,
+                                                      run.tracker,
                                                       subset,
                                                       state.state.get(pd).apply(query),
                                                       SelectHelper.execute(sut, run.clock, query, subset),

--- a/harry-stress.sh
+++ b/harry-stress.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#!/bin/bash
+
+if [ -z "$(ls -A cassandra)" ]; then
+    echo -e "\nPlease build harry first using 'make package' before running stress\n"
+    exit 1
+fi
+
+usage() {
+    echo
+    echo "usage: harry-stress.sh [args]"
+    echo "  -f --flag           Flag last run as a failure (dir name + touch file indicating)"
+    echo "  -t --title          Optional title to decorate the results directory with internally in 'title.txt'"
+    echo "  -d --duration       Time in ms to run test (default 60000)"
+    echo "  -m --minutes        Alternate duration in minutes"
+    echo "  -r --read           # Read threads. default 2"
+    echo "  -w --write          # Write threads. default 2"
+    echo "  -s --seed           seed. Defaults to random in 0-1e13"
+    echo "  -c --conf           .yaml config file. Defaults to conf/external.yaml"
+    echo "  -v --validate       validation type. Defaults to validate-all"
+    echo
+    exit 0
+}
+
+# Sanity check; confirm harry's been built
+
+title=""
+duration=60000
+read=2
+write=2
+seed=`awk -v min=1 -v max=9999999999999 'BEGIN{srand(); print int(min + rand() * (max - min+1))}'`
+conf_file="conf/external.yaml"
+validate="validate-all"
+
+
+while test $# -gt 0
+    do
+    case "$1" in
+        -h|--help)
+            usage
+            exit
+            ;;
+        -f|--flag)
+            TO_FLAG=$(ls -td results/* | head -1)
+            echo "Flagging $TO_FLAG as a failure"
+            fail_dir=${TO_FLAG}_FAILED
+            mv $TO_FLAG $fail_dir
+            touch $fail_dir/failure.txt
+            echo "See $fail_dir for detailed results"
+            exit
+            ;;
+        -t|--title)
+            title=$2
+            shift
+            ;;
+        -d|--duration)
+            duration=$2
+            shift
+            ;;
+        -r|--read)
+            read=$2
+            shift
+            ;;
+        -w|--write)
+            write=$2
+            shift
+            ;;
+        -s|--seed)
+            seed=$2
+            shift
+            ;;
+        -c|--conf)
+            conf=$2
+            shift
+            ;;
+        -v|--validate)
+            validate=$2
+            shift
+            ;;
+        -m|--minutes)
+            duration=$(($2 * 1000 * 60))
+            shift
+            ;;
+        *)
+            echo "Unknown arg $1"
+            usage
+            ;;
+    esac
+    shift
+done
+
+java_version=`java -version 2>&1 | grep version | cut -d "\"" -f2`
+file_prefix="_s${seed}_r${read}_w${write}_${validate}_JDK${java_version}"
+run_time="`date +%Y-%m-%d_%s`"
+
+# Default to verbose run name if not provided by user; can't infer run intent
+run_name=${run_time}_$file_prefix
+results_dir="results/$run_name"
+
+if [[ ! -z $title ]]; then
+    results_dir="results/$title"
+fi
+
+if [ -d $results_dir ];
+then
+    echo "$results_dir already exists; please re-title your test with -t"
+    exit -1
+fi
+
+mkdir -p $results_dir
+touch $results_dir/$title.txt
+
+echo "seed: $seed" > $results_dir/${file_prefix}_seed.txt
+perl -pi -e "s/seed:*.*$/seed: $seed/g" $conf_file
+echo "Confirming seed replacement in $conf_file" >> $results_dir/${file_prefix}_seed.txt
+grep seed $conf_file >> $results_dir/${file_prefix}_seed.txt
+
+export ARGS="$conf_file --read=$read --write=$write --duration=$duration --$validate"
+cmd="make -o package stress"
+echo Running command: [$cmd ARGS=\"$ARGS\"] >> $results_dir/${file_prefix}_cmd.txt
+
+# TODO: Consider catching return code on stress command and flagging dir as FAILURE automatically
+# Do we get a return code from ministress?
+$cmd >> $results_dir/${file_prefix}_stress_results.txt 2>&1 &
+sleep 1
+tail -f $results_dir/*

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
                 <module>harry-core</module>
                 <module>harry-integration</module>
                 <module>harry-integration-external</module>
+                <module>harry-examples</module>
             </modules>
         </profile>
         <profile>
@@ -62,13 +63,16 @@
         </profile>
     </profiles>
     <properties>
-        <skipTests>true</skipTests>
         <javac.target>1.8</javac.target>
         <harry.version>0.0.1-SNAPSHOT</harry.version>
-        <cassandra.version>4.0.1-1a05fcf52b</cassandra.version>
         <jackson.version>2.11.3</jackson.version>
-        <dtest.version>0.0.7</dtest.version>
+        <dtest.version>0.0.13</dtest.version>
         <jmh.version>1.11.3</jmh.version>
+        <!--
+        This is built from the cassandra/ submodule, see property dtest-local.version in relocate-dependencies.pom
+        -->
+        <cassandra.version>4.0.0-SNAPSHOT</cassandra.version>
+
         <argLine.common>
             -server
             -dsa -da -ea
@@ -133,68 +137,60 @@
 
     <dependencyManagement>
         <dependencies>
-
-
-            <dependency>
-                <groupId>org.apache.cassandra</groupId>
-                <artifactId>dtest-api</artifactId>
-                <version>${dtest.version}</version>
-           </dependency>
-
-            <dependency>
-                <groupId>org.apache.ant</groupId>
-                <artifactId>ant-junit</artifactId>
-                <version>1.9.7</version>
-            </dependency>
-
+            <!--
+            This dependency is built from the cassandra/ git submodule, not pulled from a remote repository.
+            Run "make package" to build it and install it into your local repository.
+            -->
             <dependency>
                 <groupId>org.apache.cassandra</groupId>
                 <artifactId>cassandra-dtest-shaded</artifactId>
                 <version>${cassandra.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.apache.cassandra</groupId>
+                <artifactId>dtest-api</artifactId>
+                <version>${dtest.version}</version>
+           </dependency>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant-junit</artifactId>
+                <version>1.9.7</version>
+            </dependency>
             <dependency>
                 <groupId>org.reflections</groupId>
                 <artifactId>reflections</artifactId>
                 <version>0.10.2</version>
             </dependency>
-
-	    <dependency>
-	      <groupId>com.datastax.cassandra</groupId>
-              <artifactId>cassandra-driver-core</artifactId>
-              <version>3.6.0</version>
-	    </dependency>
-
+            <dependency>
+              <groupId>com.datastax.cassandra</groupId>
+                  <artifactId>cassandra-driver-core</artifactId>
+                  <version>3.6.0</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-math3</artifactId>
                 <version>3.2</version>
             </dependency>
-
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
                 <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>
             </dependency>
-
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>

--- a/test/conf/cassandra.yaml
+++ b/test/conf/cassandra.yaml
@@ -6,8 +6,7 @@ cluster_name: Test Cluster
 # memtable_allocation_type: heap_buffers
 memtable_allocation_type: offheap_objects
 commitlog_sync: batch
-commitlog_sync_batch_window_in_ms: 1.0
-commitlog_segment_size_in_mb: 5
+commitlog_segment_size: 5MiB
 commitlog_directory: build/test/cassandra/commitlog
 # commitlog_compression:
 # - class_name: LZ4Compressor
@@ -17,37 +16,99 @@ hints_directory: build/test/cassandra/hints
 partitioner: org.apache.cassandra.dht.ByteOrderedPartitioner
 listen_address: 127.0.0.1
 storage_port: 7012
-ssl_storage_port: 7011
+ssl_storage_port: 17012
 start_native_transport: true
 native_transport_port: 9042
-column_index_size_in_kb: 4
+column_index_size: 4KiB
 saved_caches_directory: build/test/cassandra/saved_caches
 data_file_directories:
-  - build/test/cassandra/data
+    - build/test/cassandra/data
 disk_access_mode: mmap
 seed_provider:
-  - class_name: org.apache.cassandra.locator.SimpleSeedProvider
-    parameters:
-      - seeds: "127.0.0.1:7012"
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          - seeds: "127.0.0.1:7012"
 endpoint_snitch: org.apache.cassandra.locator.SimpleSnitch
 dynamic_snitch: true
 server_encryption_options:
-  internode_encryption: none
-  keystore: conf/.keystore
-  keystore_password: cassandra
-  truststore: conf/.truststore
-  truststore_password: cassandra
+    internode_encryption: none
+    keystore: conf/.keystore
+    keystore_password: cassandra
+    truststore: conf/.truststore
+    truststore_password: cassandra
 incremental_backups: true
 concurrent_compactors: 4
-compaction_throughput_mb_per_sec: 0
+compaction_throughput: 0MiB/s
 row_cache_class_name: org.apache.cassandra.cache.OHCProvider
-row_cache_size_in_mb: 16
-enable_user_defined_functions: true
-enable_scripted_user_defined_functions: true
-prepared_statements_cache_size_mb: 1
+row_cache_size: 16MiB
+user_defined_functions_enabled: true
+scripted_user_defined_functions_enabled: false
+prepared_statements_cache_size: 1MiB
 corrupted_tombstone_strategy: exception
 stream_entire_sstables: true
-stream_throughput_outbound_megabits_per_sec: 200000000
-enable_sasi_indexes: true
-enable_materialized_views: true
+stream_throughput_outbound: 23841858MiB/s
+sasi_indexes_enabled: true
+materialized_views_enabled: true
+drop_compact_storage_enabled: true
 file_cache_enabled: true
+full_query_logging_options:
+  allow_nodetool_archive_command: true
+auto_hints_cleanup_enabled: true
+
+heap_dump_path: build/test
+dump_heap_on_uncaught_exception: false
+
+read_thresholds_enabled: true
+coordinator_read_size_warn_threshold: 1024KiB
+coordinator_read_size_fail_threshold: 4096KiB
+local_read_size_warn_threshold: 4096KiB
+local_read_size_fail_threshold: 8192KiB
+row_index_read_size_warn_threshold: 4096KiB
+row_index_read_size_fail_threshold: 8192KiB
+
+memtable:
+    configurations:
+        skiplist:
+            class_name: SkipListMemtable
+        trie:
+            class_name: TrieMemtable
+            parameters:
+                shards: 4
+        skiplist_sharded:
+            class_name: ShardedSkipListMemtable
+            parameters:
+                serialize_writes: false
+        skiplist_sharded_locking:
+            inherits: skiplist_sharded
+            parameters:
+                serialize_writes: true
+        skiplist_remapped:
+            inherits: skiplist
+        test_fullname:
+            class_name: org.apache.cassandra.db.memtable.TestMemtable
+        test_shortname:
+            class_name: TestMemtable
+            parameters:
+                skiplist: true  # note: YAML must interpret this as string, not a boolean
+        test_empty_class:
+            class_name: ""
+        test_missing_class:
+            parameters:
+        test_unknown_class:
+            class_name: NotExisting
+        test_invalid_param:
+            class_name: SkipListMemtable
+            parameters:
+                invalid: throw
+        test_invalid_extra_param:
+            inherits: test_shortname
+            parameters:
+                invalid: throw
+        test_invalid_factory_method:
+            class_name: org.apache.cassandra.cql3.validation.operations.CreateTest$InvalidMemtableFactoryMethod
+        test_invalid_factory_field:
+            class_name: org.apache.cassandra.cql3.validation.operations.CreateTest$InvalidMemtableFactoryField
+        test_memtable_metrics:
+            class_name: TrieMemtable
+# Note: keep the memtable configuration at the end of the file, so that the default mapping can be changed without
+# duplicating the whole section above.


### PR DESCRIPTION
      * Add an ability to run sequential r/w for more deterministic results
      * Implement Network Topology Strategy
      * Add all pds iterator to ops selector
      * Make sure to log when detecting that a run starts against a dirty table
      * Fix a concurrency issue with reorder buffer
      * Add some safety wheels / debugging instruments
      * Add a pd selector symmetry test
      * Make it simpler to write and log
      * Rename sequential rw to write before read
      * Avoid starving writers by readers and vice versa
      * Add a minimal guide for debugging falsifications
      * Fix select peers query for local state checker
      * Add examples for programmatic configuration