### PR TITLE
Fix version in run-external.sh

### DIFF
--- a/run-external.sh
+++ b/run-external.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -Dlogback.configurationFile=test/conf/logback-dtest.xml -jar harry-integration-external/target/harry-integration-external-0.0.1-SNAPSHOT.jar conf/external.yaml
+java -Dlogback.configurationFile=test/conf/logback-dtest.xml -jar harry-integration-external/target/harry-integration-external-0.0.2-SNAPSHOT.jar conf/external.yaml


### PR DESCRIPTION
run-external.sh has 0.0.1 version for the harry-integration-external-0.0.1-SNAPSHOT.jar; however, pom.xml has 0.0.2. So in this ticket, fix the version in run-external.sh

